### PR TITLE
feat - 소셜 탭 마무리

### DIFF
--- a/KillingPart.xcodeproj/project.pbxproj
+++ b/KillingPart.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KillingPart/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "킬링파트";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -459,7 +459,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -489,7 +489,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KillingPart/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "킬링파트";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.lifestyle";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -504,7 +504,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0.25;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/KillingPart.xcodeproj/project.pbxproj
+++ b/KillingPart.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 27;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -459,7 +459,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -479,7 +479,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 27;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -504,7 +504,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/KillingPart/Models/DiaryModel.swift
+++ b/KillingPart/Models/DiaryModel.swift
@@ -143,6 +143,10 @@ struct DiaryCreateRequest: Encodable {
     let end: String
 }
 
+struct DiaryReportRequest: Encodable {
+    let content: String
+}
+
 struct DiaryCreateResult {
     let diaryId: Int?
     let location: String?

--- a/KillingPart/Services/DiaryService.swift
+++ b/KillingPart/Services/DiaryService.swift
@@ -4,6 +4,7 @@ protocol DiaryServicing {
     func fetchMyDiaries(page: Int, size: Int) async throws -> MyDiaryFeedsResponse
     func fetchMyFeeds(page: Int, size: Int) async throws -> MyDiaryFeedsResponse
     func fetchUserFeeds(userId: Int, page: Int, size: Int) async throws -> UserDiaryFeedsResponse
+    func fetchDiaryLikeUsers(diaryId: Int, searchCond: String?, page: Int, size: Int) async throws -> UserSearchResponse
     func createDiary(request: DiaryCreateRequest) async throws -> DiaryCreateResult
     func updateDiary(diaryId: Int, request: DiaryUpdateRequest) async throws
     func deleteDiary(diaryId: Int) async throws
@@ -118,6 +119,40 @@ struct DiaryService: DiaryServicing {
             )
 
             return try await apiClient.request(request, responseType: UserDiaryFeedsResponse.self)
+        } catch {
+            if isRequestCancelled(error) { throw error }
+            throw mapError(error)
+        }
+    }
+
+    func fetchDiaryLikeUsers(
+        diaryId: Int,
+        searchCond: String? = nil,
+        page: Int = Self.defaultPage,
+        size: Int = Self.defaultSize
+    ) async throws -> UserSearchResponse {
+        let resolvedPage = max(page, Self.defaultPage)
+        let resolvedSize = size > 0 ? size : Self.defaultSize
+        let trimmedSearchCond = searchCond?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        var queryItems = [
+            URLQueryItem(name: "page", value: String(resolvedPage)),
+            URLQueryItem(name: "size", value: String(resolvedSize))
+        ]
+
+        if !trimmedSearchCond.isEmpty {
+            queryItems.insert(URLQueryItem(name: "searchCond", value: trimmedSearchCond), at: 0)
+        }
+
+        do {
+            let request = APIRequest(
+                path: "/diaries/\(diaryId)/like",
+                method: .get,
+                queryItems: queryItems,
+                requiresAuthorization: true
+            )
+            let response = try await apiClient.request(request, responseType: UserSearchResponseDTO.self)
+            return response.toModel()
         } catch {
             if isRequestCancelled(error) { throw error }
             throw mapError(error)

--- a/KillingPart/Services/DiaryService.swift
+++ b/KillingPart/Services/DiaryService.swift
@@ -11,6 +11,7 @@ protocol DiaryServicing {
     func updateMyDiaryOrder(request: DiaryOrderUpdateRequest) async throws
     func toggleDiaryLike(diaryId: Int) async throws -> DiaryLikeToggleResponse
     func toggleDiaryStore(diaryId: Int) async throws -> DiaryStoreToggleResponse
+    func reportDiary(diaryId: Int, content: String) async throws
 }
 
 enum DiaryServiceError: LocalizedError {
@@ -279,6 +280,32 @@ struct DiaryService: DiaryServicing {
         }
     }
 
+    func reportDiary(diaryId: Int, content: String) async throws {
+        let requestBody: Data
+        do {
+            requestBody = try JSONEncoder().encode(
+                DiaryReportRequest(content: content.trimmingCharacters(in: .whitespacesAndNewlines))
+            )
+        } catch {
+            throw DiaryServiceError.requestEncodingFailed
+        }
+
+        do {
+            var request = APIRequest(
+                path: "/diaries/\(diaryId)/reports",
+                method: .post,
+                requiresAuthorization: true,
+                body: requestBody
+            )
+            request.headers["Accept"] = "application/json"
+            request.headers["Content-Type"] = "application/json"
+            try await apiClient.request(request)
+        } catch {
+            if isRequestCancelled(error) { throw error }
+            throw mapError(error)
+        }
+    }
+
     private func mapError(_ error: Error) -> DiaryServiceError {
         if let diaryServiceError = error as? DiaryServiceError {
             return diaryServiceError
@@ -291,13 +318,51 @@ struct DiaryService: DiaryServicing {
             case .missingAccessToken, .missingRefreshToken, .unauthorized:
                 return .sessionExpired
             case .serverError(let statusCode, let message):
-                return .serverError(statusCode: statusCode, message: message)
+                return .serverError(
+                    statusCode: statusCode,
+                    message: normalizeServerErrorMessage(message)
+                )
             case .decodingFailed:
                 return .decodingFailed
             }
         }
 
         return .networkFailure(message: "네트워크 요청 중 오류가 발생했어요.")
+    }
+
+    private func normalizeServerErrorMessage(_ rawMessage: String?) -> String? {
+        guard
+            let rawMessage = rawMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawMessage.isEmpty
+        else {
+            return nil
+        }
+
+        guard
+            rawMessage.first == "{",
+            let data = rawMessage.data(using: .utf8),
+            let parsed = try? JSONDecoder().decode(DiaryServiceErrorResponse.self, from: data)
+        else {
+            return rawMessage
+        }
+
+        if let message = parsed.message?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !message.isEmpty {
+            return message
+        }
+
+        let fieldMessages = (parsed.fieldErrors ?? [])
+            .flatMap(\.values)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let globalMessages = (parsed.globalErrors ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let merged = fieldMessages + globalMessages
+        guard !merged.isEmpty else { return rawMessage }
+        return merged.joined(separator: "\n")
     }
 
     private func extractDiaryID(from location: String?) -> Int? {
@@ -318,4 +383,10 @@ struct DiaryService: DiaryServicing {
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
+}
+
+private struct DiaryServiceErrorResponse: Decodable {
+    let message: String?
+    let fieldErrors: [[String: String]]?
+    let globalErrors: [String]?
 }

--- a/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
+++ b/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
@@ -11,11 +11,20 @@ final class MyCollectionDiaryViewModel: ObservableObject {
     @Published private(set) var isProcessing = false
     @Published private(set) var isUpdatingInteraction = false
     @Published private(set) var isDeleted = false
+    @Published private(set) var likeUsers: [UserModel] = []
+    @Published private(set) var isLoadingLikeUsers = false
+    @Published private(set) var isLoadingMoreLikeUsers = false
+    @Published var likeUsersErrorMessage: String?
     @Published var errorMessage: String?
 
     private let diaryService: DiaryServicing
     private var isRefreshingInteractionState = false
     private let maxRefreshScanPageCount = 100
+    private let likeUsersPageSize = 20
+    private var activeLikeUsersSearchCond: String?
+    private var likeUsersNextPage = DiaryService.defaultPage
+    private var hasNextLikeUsersPage = true
+    private var likeUsersRequestID = 0
 
     init(
         diary: DiaryFeedModel,
@@ -197,6 +206,76 @@ final class MyCollectionDiaryViewModel: ObservableObject {
         }
     }
 
+    func loadLikeUsers(searchCond: String? = nil) async {
+        likeUsersRequestID += 1
+        let requestID = likeUsersRequestID
+        activeLikeUsersSearchCond = normalizedSearchCond(searchCond)
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = true
+        defer {
+            if likeUsersRequestID == requestID {
+                isLoadingLikeUsers = false
+            }
+        }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: diary.diaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: DiaryService.defaultPage,
+                size: likeUsersPageSize
+            )
+            guard likeUsersRequestID == requestID else { return }
+            likeUsers = response.content
+            updateLikeUsersPaging(from: response)
+        } catch {
+            guard likeUsersRequestID == requestID else { return }
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func loadMoreLikeUsersIfNeeded(currentUserId: Int) async {
+        guard likeUsers.last?.userId == currentUserId else { return }
+        guard hasNextLikeUsersPage else { return }
+        guard !isLoadingLikeUsers, !isLoadingMoreLikeUsers else { return }
+
+        isLoadingMoreLikeUsers = true
+        defer { isLoadingMoreLikeUsers = false }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: diary.diaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: likeUsersNextPage,
+                size: likeUsersPageSize
+            )
+            appendLikeUsers(with: response.content)
+            updateLikeUsersPaging(from: response)
+        } catch {
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func retryLikeUsersLoading() async {
+        await loadLikeUsers(searchCond: activeLikeUsersSearchCond)
+    }
+
+    func clearLikeUsersState() {
+        likeUsersRequestID += 1
+        activeLikeUsersSearchCond = nil
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = false
+        isLoadingMoreLikeUsers = false
+    }
+
     private var trimmedEditContent: String {
         editContentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -316,6 +395,25 @@ final class MyCollectionDiaryViewModel: ObservableObject {
         }
 
         return nil
+    }
+
+    private func appendLikeUsers(with newUsers: [UserModel]) {
+        let existingIDs = Set(likeUsers.map(\.userId))
+        let filtered = newUsers.filter { !existingIDs.contains($0.userId) }
+        likeUsers.append(contentsOf: filtered)
+    }
+
+    private func updateLikeUsersPaging(from response: UserSearchResponse) {
+        likeUsersNextPage = max(response.page.number, 0) + 1
+        let totalPages = max(response.page.totalPages, 0)
+        let hasNextByPage = likeUsersNextPage < totalPages
+        let hasNextByCount = response.content.count >= likeUsersPageSize
+        hasNextLikeUsersPage = hasNextByPage || hasNextByCount
+    }
+
+    private func normalizedSearchCond(_ searchCond: String?) -> String? {
+        let trimmed = searchCond?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func resolveErrorMessage(from error: Error) -> String {

--- a/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
+++ b/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
@@ -14,6 +14,8 @@ final class MyCollectionDiaryViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     private let diaryService: DiaryServicing
+    private var isRefreshingInteractionState = false
+    private let maxRefreshScanPageCount = 100
 
     init(
         diary: DiaryFeedModel,
@@ -173,6 +175,28 @@ final class MyCollectionDiaryViewModel: ObservableObject {
         }
     }
 
+    func refreshInteractionStateIfNeeded(preferredUserId: Int? = nil) async {
+        guard !isDeleted, !isProcessing, !isUpdatingInteraction else { return }
+        guard !isRefreshingInteractionState else { return }
+
+        isRefreshingInteractionState = true
+        defer { isRefreshingInteractionState = false }
+
+        do {
+            guard let latestInteraction = try await fetchLatestInteractionState(preferredUserId: preferredUserId) else {
+                return
+            }
+            diary = diary.replacingInteraction(
+                isLiked: latestInteraction.isLiked,
+                isStored: latestInteraction.isStored,
+                likeCount: latestInteraction.likeCount
+            )
+        } catch {
+            if isRequestCancelled(error) { return }
+            errorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
     private var trimmedEditContent: String {
         editContentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -204,6 +228,91 @@ final class MyCollectionDiaryViewModel: ObservableObject {
 
         if let raw = Double(sanitized) {
             return max(raw, 0)
+        }
+
+        return nil
+    }
+
+    private func fetchLatestInteractionState(
+        preferredUserId: Int?
+    ) async throws -> (isLiked: Bool, isStored: Bool, likeCount: Int)? {
+        let resolvedUserId: Int?
+        if let preferredUserId, preferredUserId > 0 {
+            resolvedUserId = preferredUserId
+        } else if diary.userId > 0 {
+            resolvedUserId = diary.userId
+        } else {
+            resolvedUserId = nil
+        }
+
+        if let resolvedUserId,
+           let userFeedInteraction = try await findInteractionInUserFeeds(userId: resolvedUserId) {
+            return userFeedInteraction
+        }
+
+        return try await findInteractionInMyFeeds()
+    }
+
+    private func findInteractionInUserFeeds(
+        userId: Int
+    ) async throws -> (isLiked: Bool, isStored: Bool, likeCount: Int)? {
+        var page = DiaryService.defaultPage
+
+        for _ in 0..<maxRefreshScanPageCount {
+            let response = try await diaryService.fetchUserFeeds(
+                userId: userId,
+                page: page,
+                size: DiaryService.defaultSize
+            )
+
+            if let targetDiary = response.content.first(where: { $0.diaryId == diary.diaryId }) {
+                return (
+                    isLiked: targetDiary.isLiked,
+                    isStored: targetDiary.isStored,
+                    likeCount: targetDiary.likeCount
+                )
+            }
+
+            let nextPage = max(response.page.number, 0) + 1
+            let totalPages = max(response.page.totalPages, 0)
+            let hasNextByPage = nextPage < totalPages
+            let hasNextByCount = response.content.count >= DiaryService.defaultSize
+            guard hasNextByPage || hasNextByCount else {
+                return nil
+            }
+
+            page = nextPage
+        }
+
+        return nil
+    }
+
+    private func findInteractionInMyFeeds() async throws -> (isLiked: Bool, isStored: Bool, likeCount: Int)? {
+        var page = DiaryService.defaultPage
+
+        for _ in 0..<maxRefreshScanPageCount {
+            let response = try await diaryService.fetchMyFeeds(
+                page: page,
+                size: DiaryService.defaultSize
+            )
+
+            if let targetDiary = response.content.first(where: { $0.diaryId == diary.diaryId }) {
+                return (
+                    isLiked: targetDiary.isLiked,
+                    isStored: targetDiary.isStored,
+                    likeCount: targetDiary.likeCount
+                )
+            }
+
+            let nextPage = max(response.page.number, 0) + 1
+            let totalPages = max(response.page.totalPages, 0)
+            let hasNextByPage = nextPage < totalPages
+            let hasNextByCount = response.content.count >= DiaryService.defaultSize
+            guard hasNextByPage || hasNextByCount else {
+                return nil
+            }
+
+            page = nextPage
         }
 
         return nil

--- a/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
+++ b/KillingPart/ViewModels/My/MyCollection/MyCollectionDiaryViewModel.swift
@@ -9,6 +9,7 @@ final class MyCollectionDiaryViewModel: ObservableObject {
     @Published var editContentDraft: String
     @Published var isEditMode = false
     @Published private(set) var isProcessing = false
+    @Published private(set) var isUpdatingInteraction = false
     @Published private(set) var isDeleted = false
     @Published var errorMessage: String?
 
@@ -111,6 +112,62 @@ final class MyCollectionDiaryViewModel: ObservableObject {
             return true
         } catch {
             if isRequestCancelled(error) { return false }
+            errorMessage = resolveErrorMessage(from: error)
+            return false
+        }
+    }
+
+    func toggleLike() async -> Bool {
+        guard !isProcessing, !isUpdatingInteraction, !isDeleted else { return false }
+
+        let originalDiary = diary
+        let toggledIsLiked = !originalDiary.isLiked
+        let optimisticLikeCount = max(originalDiary.likeCount + (toggledIsLiked ? 1 : -1), 0)
+        diary = originalDiary.replacingInteraction(
+            isLiked: toggledIsLiked,
+            likeCount: optimisticLikeCount
+        )
+        errorMessage = nil
+        isUpdatingInteraction = true
+        defer { isUpdatingInteraction = false }
+
+        do {
+            let response = try await diaryService.toggleDiaryLike(diaryId: originalDiary.diaryId)
+            let currentDiary = diary
+            let confirmedLikeCount = max(
+                currentDiary.likeCount + (response.isLiked == currentDiary.isLiked ? 0 : (response.isLiked ? 1 : -1)),
+                0
+            )
+            diary = currentDiary.replacingInteraction(
+                isLiked: response.isLiked,
+                likeCount: confirmedLikeCount
+            )
+            return true
+        } catch {
+            if isRequestCancelled(error) { return false }
+            diary = originalDiary
+            errorMessage = resolveErrorMessage(from: error)
+            return false
+        }
+    }
+
+    func toggleStore() async -> Bool {
+        guard !isProcessing, !isUpdatingInteraction, !isDeleted else { return false }
+
+        let originalDiary = diary
+        let toggledIsStored = !originalDiary.isStored
+        diary = originalDiary.replacingInteraction(isStored: toggledIsStored)
+        errorMessage = nil
+        isUpdatingInteraction = true
+        defer { isUpdatingInteraction = false }
+
+        do {
+            let response = try await diaryService.toggleDiaryStore(diaryId: originalDiary.diaryId)
+            diary = diary.replacingInteraction(isStored: response.isStored)
+            return true
+        } catch {
+            if isRequestCancelled(error) { return false }
+            diary = originalDiary
             errorMessage = resolveErrorMessage(from: error)
             return false
         }

--- a/KillingPart/ViewModels/My/MyCollection/MyCollectionViewModel.swift
+++ b/KillingPart/ViewModels/My/MyCollection/MyCollectionViewModel.swift
@@ -14,11 +14,20 @@ final class MyCollectionViewModel: ObservableObject {
     @Published private(set) var userStatics: UserStaticsModel?
     @Published private(set) var myFeeds: [DiaryFeedModel] = []
     @Published private(set) var isLoadingMoreFeeds = false
+    @Published private(set) var connectionUsers: [SubscribeUserModel] = []
+    @Published private(set) var isLoadingConnections = false
+    @Published private(set) var isLoadingMoreConnections = false
+    @Published private(set) var likeUsers: [UserModel] = []
+    @Published private(set) var isLoadingLikeUsers = false
+    @Published private(set) var isLoadingMoreLikeUsers = false
+    @Published var connectionErrorMessage: String?
+    @Published var likeUsersErrorMessage: String?
     @Published var errorMessage: String?
 
     private let authenticationService: AuthenticationServicing
     private let userService: UserServicing
     private let diaryService: DiaryServicing
+    private let subscribeService: SubscribeServicing
 
     private var hasLoadedProfile = false
     private var hasLoadedUserStatics = false
@@ -31,15 +40,27 @@ final class MyCollectionViewModel: ObservableObject {
     private var hasNextFeedPage = true
     private var hasPendingBottomPaginationRequest = false
     private var hasPendingFocusRefetchRequest = false
+    private var activeConnectionType: ConnectionType?
+    private var nextConnectionPage = SubscribeService.defaultPage
+    private var hasNextConnectionPage = true
+    private var connectionRequestID = 0
+    private let likeUsersPageSize = 20
+    private var activeLikeUsersDiaryId: Int?
+    private var activeLikeUsersSearchCond: String?
+    private var likeUsersNextPage = DiaryService.defaultPage
+    private var hasNextLikeUsersPage = true
+    private var likeUsersRequestID = 0
 
     init(
         authenticationService: AuthenticationServicing,
         userService: UserServicing = UserService(),
-        diaryService: DiaryServicing = DiaryService()
+        diaryService: DiaryServicing = DiaryService(),
+        subscribeService: SubscribeServicing = SubscribeService()
     ) {
         self.authenticationService = authenticationService
         self.userService = userService
         self.diaryService = diaryService
+        self.subscribeService = subscribeService
     }
 
     var displayName: String {
@@ -67,6 +88,168 @@ final class MyCollectionViewModel: ObservableObject {
 
     var pickStatText: String {
         "\(userStatics?.pickCount ?? 0)"
+    }
+
+    func makeSocialMyCollectionViewModel(for user: UserModel) -> SocialMyCollectionViewModel {
+        SocialMyCollectionViewModel(
+            initialUser: user,
+            userService: userService,
+            diaryService: diaryService,
+            subscribeService: subscribeService,
+            onToggleMyPick: { [self] userId, isCurrentlyMyPick in
+                try await toggleMyPick(for: userId, isCurrentlyMyPick: isCurrentlyMyPick)
+            }
+        )
+    }
+
+    func makeSocialMyCollectionViewModel(for user: SubscribeUserModel) -> SocialMyCollectionViewModel {
+        makeSocialMyCollectionViewModel(for: UserModel(from: user))
+    }
+
+    func loadConnections(type: ConnectionType) async {
+        if user == nil {
+            await loadMyProfileIfNeeded()
+        }
+        guard let myUserID = user?.userId else { return }
+
+        connectionRequestID += 1
+        let requestID = connectionRequestID
+        activeConnectionType = type
+        nextConnectionPage = SubscribeService.defaultPage
+        hasNextConnectionPage = true
+        connectionUsers = []
+        connectionErrorMessage = nil
+        isLoadingConnections = true
+        defer {
+            if connectionRequestID == requestID {
+                isLoadingConnections = false
+            }
+        }
+
+        do {
+            let response = try await fetchConnections(
+                userId: myUserID,
+                type: type,
+                page: SubscribeService.defaultPage
+            )
+            guard requestID == connectionRequestID else { return }
+            connectionUsers = response.content
+            updateConnectionPaging(from: response)
+        } catch {
+            guard requestID == connectionRequestID else { return }
+            if isRequestCancelled(error) { return }
+            connectionErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func loadMoreConnectionsIfNeeded(currentUserId: Int) async {
+        guard connectionUsers.last?.userId == currentUserId else { return }
+        guard hasNextConnectionPage else { return }
+        guard !isLoadingConnections, !isLoadingMoreConnections else { return }
+        guard let activeConnectionType else { return }
+
+        if user == nil {
+            await loadMyProfileIfNeeded()
+        }
+        guard let myUserID = user?.userId else { return }
+
+        isLoadingMoreConnections = true
+        defer { isLoadingMoreConnections = false }
+
+        do {
+            let response = try await fetchConnections(
+                userId: myUserID,
+                type: activeConnectionType,
+                page: nextConnectionPage
+            )
+            appendConnectionUsers(with: response.content)
+            updateConnectionPaging(from: response)
+        } catch {
+            if isRequestCancelled(error) { return }
+            connectionErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func refreshActiveConnections() async {
+        guard let activeConnectionType else { return }
+        await loadConnections(type: activeConnectionType)
+    }
+
+    func loadLikeUsers(diaryId: Int, searchCond: String? = nil) async {
+        likeUsersRequestID += 1
+        let requestID = likeUsersRequestID
+        activeLikeUsersDiaryId = diaryId
+        activeLikeUsersSearchCond = normalizedSearchCond(searchCond)
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = true
+        defer {
+            if likeUsersRequestID == requestID {
+                isLoadingLikeUsers = false
+            }
+        }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: diaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: DiaryService.defaultPage,
+                size: likeUsersPageSize
+            )
+            guard likeUsersRequestID == requestID else { return }
+            likeUsers = response.content
+            updateLikeUsersPaging(from: response)
+        } catch {
+            guard likeUsersRequestID == requestID else { return }
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func loadMoreLikeUsersIfNeeded(currentUserId: Int) async {
+        guard likeUsers.last?.userId == currentUserId else { return }
+        guard hasNextLikeUsersPage else { return }
+        guard !isLoadingLikeUsers, !isLoadingMoreLikeUsers else { return }
+        guard let activeLikeUsersDiaryId else { return }
+
+        isLoadingMoreLikeUsers = true
+        defer { isLoadingMoreLikeUsers = false }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: activeLikeUsersDiaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: likeUsersNextPage,
+                size: likeUsersPageSize
+            )
+            appendLikeUsers(with: response.content)
+            updateLikeUsersPaging(from: response)
+        } catch {
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func retryLikeUsersLoading() async {
+        guard let activeLikeUsersDiaryId else { return }
+        await loadLikeUsers(
+            diaryId: activeLikeUsersDiaryId,
+            searchCond: activeLikeUsersSearchCond
+        )
+    }
+
+    func clearLikeUsersState() {
+        likeUsersRequestID += 1
+        activeLikeUsersDiaryId = nil
+        activeLikeUsersSearchCond = nil
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = false
+        isLoadingMoreLikeUsers = false
     }
 
     func loadInitialDataIfNeeded() async {
@@ -270,6 +453,69 @@ final class MyCollectionViewModel: ObservableObject {
         }
     }
 
+    private func toggleMyPick(for userId: Int, isCurrentlyMyPick: Bool) async throws {
+        if isCurrentlyMyPick {
+            try await subscribeService.unsubscribe(from: userId)
+        } else {
+            try await subscribeService.subscribe(to: userId)
+        }
+        await refetchCollectionDataOnFocus()
+    }
+
+    private func fetchConnections(
+        userId: Int,
+        type: ConnectionType,
+        page: Int
+    ) async throws -> SubscribeListResponse {
+        switch type {
+        case .picks:
+            return try await subscribeService.fetchSubscribes(
+                userId: userId,
+                page: page,
+                size: SubscribeService.defaultSize
+            )
+        case .fandom:
+            return try await subscribeService.fetchSubscribers(
+                userId: userId,
+                page: page,
+                size: SubscribeService.defaultSize
+            )
+        }
+    }
+
+    private func appendConnectionUsers(with newUsers: [SubscribeUserModel]) {
+        let existingIDs = Set(connectionUsers.map(\.userId))
+        let filtered = newUsers.filter { !existingIDs.contains($0.userId) }
+        connectionUsers.append(contentsOf: filtered)
+    }
+
+    private func updateConnectionPaging(from response: SubscribeListResponse) {
+        nextConnectionPage = max(response.page.number, 0) + 1
+        let totalPages = max(response.page.totalPages, 0)
+        let hasNextByPage = nextConnectionPage < totalPages
+        let hasNextByCount = response.content.count >= SubscribeService.defaultSize
+        hasNextConnectionPage = hasNextByPage || hasNextByCount
+    }
+
+    private func appendLikeUsers(with newUsers: [UserModel]) {
+        let existingIDs = Set(likeUsers.map(\.userId))
+        let filtered = newUsers.filter { !existingIDs.contains($0.userId) }
+        likeUsers.append(contentsOf: filtered)
+    }
+
+    private func updateLikeUsersPaging(from response: UserSearchResponse) {
+        likeUsersNextPage = max(response.page.number, 0) + 1
+        let totalPages = max(response.page.totalPages, 0)
+        let hasNextByPage = likeUsersNextPage < totalPages
+        let hasNextByCount = response.content.count >= likeUsersPageSize
+        hasNextLikeUsersPage = hasNextByPage || hasNextByCount
+    }
+
+    private func normalizedSearchCond(_ searchCond: String?) -> String? {
+        let trimmed = searchCond?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     private func normalizeFeedVideoURLs(in feeds: [DiaryFeedModel]) -> [DiaryFeedModel] {
         feeds.map { feed in
             let normalizedVideoURL = resolvedVideoURLForPlayback(from: feed.videoUrl)
@@ -302,12 +548,21 @@ final class MyCollectionViewModel: ObservableObject {
             && !value.contains(".")
     }
 
+    enum ConnectionType {
+        case picks
+        case fandom
+    }
+
     private enum FeedLoadMode {
         case initial
         case pagination
     }
 
     private func resolveErrorMessage(from error: Error) -> String {
+        if let subscribeError = error as? SubscribeServiceError {
+            return subscribeError.errorDescription ?? "요청 처리에 실패했어요."
+        }
+
         if let diaryServiceError = error as? DiaryServiceError {
             return diaryServiceError.errorDescription ?? "요청 처리에 실패했어요."
         }

--- a/KillingPart/ViewModels/Social/FeedViewModel.swift
+++ b/KillingPart/ViewModels/Social/FeedViewModel.swift
@@ -8,8 +8,10 @@ final class FeedViewModel: ObservableObject {
     @Published private(set) var likeUsers: [UserModel] = []
     @Published private(set) var isLoadingLikeUsers = false
     @Published private(set) var isLoadingMoreLikeUsers = false
+    @Published private(set) var isReportingDiary = false
     @Published var errorMessage: String?
     @Published var likeUsersErrorMessage: String?
+    @Published var reportErrorMessage: String?
 
     private let diaryService: DiaryServicing
     private var hasLoadedInitialData = false
@@ -192,6 +194,10 @@ final class FeedViewModel: ObservableObject {
         isLoadingMoreLikeUsers = false
     }
 
+    func clearDiaryReportState() {
+        reportErrorMessage = nil
+    }
+
     func loadMoreIfNeeded(currentDiaryId: Int) async {
         guard feeds.last?.diaryId == currentDiaryId else { return }
         guard hasNextPage else { return }
@@ -260,6 +266,33 @@ final class FeedViewModel: ObservableObject {
                 feeds[rollbackIndex] = originalFeed
             }
             errorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func reportDiary(diaryId: Int, content: String) async -> Bool {
+        guard !isReportingDiary else { return false }
+
+        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedContent.isEmpty else {
+            reportErrorMessage = "빈칸은 입력할 수 없습니다."
+            return false
+        }
+        guard trimmedContent.count <= 200 else {
+            reportErrorMessage = "신고 내용은 1자 이상 200자 이하입니다."
+            return false
+        }
+
+        reportErrorMessage = nil
+        isReportingDiary = true
+        defer { isReportingDiary = false }
+
+        do {
+            try await diaryService.reportDiary(diaryId: diaryId, content: trimmedContent)
+            return true
+        } catch {
+            if isRequestCancelled(error) { return false }
+            reportErrorMessage = resolveErrorMessage(from: error)
+            return false
         }
     }
 

--- a/KillingPart/ViewModels/Social/FeedViewModel.swift
+++ b/KillingPart/ViewModels/Social/FeedViewModel.swift
@@ -11,6 +11,9 @@ final class FeedViewModel: ObservableObject {
     private var hasLoadedInitialData = false
     private var nextPage = DiaryService.defaultPage
     private var hasNextPage = true
+    private var isRefreshingInteractions = false
+    private var lastInteractionRefreshAt: Date?
+    private let interactionRefreshCooldown: TimeInterval = 0.75
 
     init(diaryService: DiaryServicing = DiaryService()) {
         self.diaryService = diaryService
@@ -35,6 +38,67 @@ final class FeedViewModel: ObservableObject {
             feeds = response.content
             updatePaging(from: response)
             hasLoadedInitialData = true
+        } catch {
+            if isRequestCancelled(error) { return }
+            errorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func refreshLoadedFeedInteractionsIfNeeded(force: Bool = false) async {
+        guard hasLoadedInitialData else {
+            await loadInitialDataIfNeeded()
+            return
+        }
+        guard !feeds.isEmpty else { return }
+        guard !isRefreshingInteractions else { return }
+
+        if !force,
+           let lastInteractionRefreshAt,
+           Date().timeIntervalSince(lastInteractionRefreshAt) < interactionRefreshCooldown {
+            return
+        }
+
+        isRefreshingInteractions = true
+        defer {
+            isRefreshingInteractions = false
+            lastInteractionRefreshAt = Date()
+        }
+
+        do {
+            let loadedPageCount = max(
+                1,
+                Int(ceil(Double(feeds.count) / Double(max(DiaryService.defaultSize, 1))))
+            )
+
+            var latestByDiaryId: [Int: DiaryFeedModel] = [:]
+            var page = DiaryService.defaultPage
+
+            for _ in 0..<loadedPageCount {
+                let response = try await diaryService.fetchMyFeeds(
+                    page: page,
+                    size: DiaryService.defaultSize
+                )
+                response.content.forEach { latestByDiaryId[$0.diaryId] = $0 }
+
+                let nextPage = max(response.page.number, 0) + 1
+                let totalPages = max(response.page.totalPages, 0)
+                let hasNextByPage = nextPage < totalPages
+                let hasNextByCount = response.content.count >= DiaryService.defaultSize
+                let hasNext = hasNextByPage || hasNextByCount
+
+                guard hasNext else { break }
+                page = nextPage
+            }
+
+            guard !latestByDiaryId.isEmpty else { return }
+            feeds = feeds.map { feed in
+                guard let latestFeed = latestByDiaryId[feed.diaryId] else { return feed }
+                return feed.replacingInteraction(
+                    isLiked: latestFeed.isLiked,
+                    isStored: latestFeed.isStored,
+                    likeCount: latestFeed.likeCount
+                )
+            }
         } catch {
             if isRequestCancelled(error) { return }
             errorMessage = resolveErrorMessage(from: error)

--- a/KillingPart/ViewModels/Social/FeedViewModel.swift
+++ b/KillingPart/ViewModels/Social/FeedViewModel.swift
@@ -5,7 +5,11 @@ final class FeedViewModel: ObservableObject {
     @Published private(set) var feeds: [DiaryFeedModel] = []
     @Published private(set) var isLoadingInitial = false
     @Published private(set) var isLoadingMore = false
+    @Published private(set) var likeUsers: [UserModel] = []
+    @Published private(set) var isLoadingLikeUsers = false
+    @Published private(set) var isLoadingMoreLikeUsers = false
     @Published var errorMessage: String?
+    @Published var likeUsersErrorMessage: String?
 
     private let diaryService: DiaryServicing
     private var hasLoadedInitialData = false
@@ -14,6 +18,12 @@ final class FeedViewModel: ObservableObject {
     private var isRefreshingInteractions = false
     private var lastInteractionRefreshAt: Date?
     private let interactionRefreshCooldown: TimeInterval = 0.75
+    private let likeUsersPageSize = 20
+    private var activeLikeUsersDiaryId: Int?
+    private var activeLikeUsersSearchCond: String?
+    private var likeUsersNextPage = DiaryService.defaultPage
+    private var hasNextLikeUsersPage = true
+    private var likeUsersRequestID = 0
 
     init(diaryService: DiaryServicing = DiaryService()) {
         self.diaryService = diaryService
@@ -105,6 +115,83 @@ final class FeedViewModel: ObservableObject {
         }
     }
 
+    func loadLikeUsers(diaryId: Int, searchCond: String? = nil) async {
+        likeUsersRequestID += 1
+        let requestID = likeUsersRequestID
+        activeLikeUsersDiaryId = diaryId
+        activeLikeUsersSearchCond = normalizedSearchCond(searchCond)
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = true
+        defer {
+            if likeUsersRequestID == requestID {
+                isLoadingLikeUsers = false
+            }
+        }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: diaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: DiaryService.defaultPage,
+                size: likeUsersPageSize
+            )
+            guard likeUsersRequestID == requestID else { return }
+            likeUsers = response.content
+            updateLikeUsersPaging(from: response)
+        } catch {
+            guard likeUsersRequestID == requestID else { return }
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func loadMoreLikeUsersIfNeeded(currentUserId: Int) async {
+        guard likeUsers.last?.userId == currentUserId else { return }
+        guard hasNextLikeUsersPage else { return }
+        guard !isLoadingLikeUsers, !isLoadingMoreLikeUsers else { return }
+        guard let activeLikeUsersDiaryId else { return }
+
+        isLoadingMoreLikeUsers = true
+        defer { isLoadingMoreLikeUsers = false }
+
+        do {
+            let response = try await diaryService.fetchDiaryLikeUsers(
+                diaryId: activeLikeUsersDiaryId,
+                searchCond: activeLikeUsersSearchCond,
+                page: likeUsersNextPage,
+                size: likeUsersPageSize
+            )
+            appendLikeUsers(with: response.content)
+            updateLikeUsersPaging(from: response)
+        } catch {
+            if isRequestCancelled(error) { return }
+            likeUsersErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func retryLikeUsersLoading() async {
+        guard let activeLikeUsersDiaryId else { return }
+        await loadLikeUsers(
+            diaryId: activeLikeUsersDiaryId,
+            searchCond: activeLikeUsersSearchCond
+        )
+    }
+
+    func clearLikeUsersState() {
+        likeUsersRequestID += 1
+        activeLikeUsersDiaryId = nil
+        activeLikeUsersSearchCond = nil
+        likeUsers = []
+        likeUsersErrorMessage = nil
+        likeUsersNextPage = DiaryService.defaultPage
+        hasNextLikeUsersPage = true
+        isLoadingLikeUsers = false
+        isLoadingMoreLikeUsers = false
+    }
+
     func loadMoreIfNeeded(currentDiaryId: Int) async {
         guard feeds.last?.diaryId == currentDiaryId else { return }
         guard hasNextPage else { return }
@@ -182,12 +269,31 @@ final class FeedViewModel: ObservableObject {
         feeds.append(contentsOf: filtered)
     }
 
+    private func appendLikeUsers(with newUsers: [UserModel]) {
+        let existingIDs = Set(likeUsers.map(\.userId))
+        let filtered = newUsers.filter { !existingIDs.contains($0.userId) }
+        likeUsers.append(contentsOf: filtered)
+    }
+
     private func updatePaging(from response: MyDiaryFeedsResponse) {
         nextPage = max(response.page.number, 0) + 1
         let totalPages = max(response.page.totalPages, 0)
         let hasNextByPage = nextPage < totalPages
         let hasNextByCount = response.content.count >= DiaryService.defaultSize
         hasNextPage = hasNextByPage || hasNextByCount
+    }
+
+    private func updateLikeUsersPaging(from response: UserSearchResponse) {
+        likeUsersNextPage = max(response.page.number, 0) + 1
+        let totalPages = max(response.page.totalPages, 0)
+        let hasNextByPage = likeUsersNextPage < totalPages
+        let hasNextByCount = response.content.count >= likeUsersPageSize
+        hasNextLikeUsersPage = hasNextByPage || hasNextByCount
+    }
+
+    private func normalizedSearchCond(_ searchCond: String?) -> String? {
+        let trimmed = searchCond?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func resolveErrorMessage(from error: Error) -> String {

--- a/KillingPart/ViewModels/Social/SocialMyCollectionViewModel.swift
+++ b/KillingPart/ViewModels/Social/SocialMyCollectionViewModel.swift
@@ -198,6 +198,22 @@ final class SocialMyCollectionViewModel: ObservableObject {
         await loadConnections(type: activeConnectionType)
     }
 
+    func makeSocialMyCollectionViewModel(for user: SubscribeUserModel) -> SocialMyCollectionViewModel {
+        makeSocialMyCollectionViewModel(for: UserModel(from: user))
+    }
+
+    func makeSocialMyCollectionViewModel(for user: UserModel) -> SocialMyCollectionViewModel {
+        SocialMyCollectionViewModel(
+            initialUser: user,
+            userService: userService,
+            diaryService: diaryService,
+            subscribeService: subscribeService,
+            onToggleMyPick: { [self] userId, isCurrentlyMyPick in
+                try await onToggleMyPick(userId, isCurrentlyMyPick)
+            }
+        )
+    }
+
     func formattedUpdateDate(from rawUpdateDate: String) -> String {
         let datePart = rawUpdateDate.split(separator: "T").first.map(String.init) ?? rawUpdateDate
         return datePart.replacingOccurrences(of: "-", with: ".")

--- a/KillingPart/ViewModels/Social/SocialMyCollectionViewModel.swift
+++ b/KillingPart/ViewModels/Social/SocialMyCollectionViewModel.swift
@@ -7,15 +7,24 @@ final class SocialMyCollectionViewModel: ObservableObject {
     @Published private(set) var feeds: [DiaryFeedModel]
     @Published private(set) var isLoadingInitial = false
     @Published private(set) var isLoadingMoreFeeds = false
+    @Published private(set) var connectionUsers: [SubscribeUserModel] = []
+    @Published private(set) var isLoadingConnections = false
+    @Published private(set) var isLoadingMoreConnections = false
     @Published var errorMessage: String?
+    @Published var connectionErrorMessage: String?
 
     private let userService: UserServicing
     private let diaryService: DiaryServicing
+    private let subscribeService: SubscribeServicing
     private let onToggleMyPick: (_ userId: Int, _ isCurrentlyMyPick: Bool) async throws -> Void
 
     private var hasLoadedInitialData = false
     private var nextFeedPage: Int
     private var hasNextFeedPage: Bool
+    private var activeConnectionType: ConnectionType?
+    private var nextConnectionPage = SubscribeService.defaultPage
+    private var hasNextConnectionPage = true
+    private var connectionRequestID = 0
 
     init(
         initialUser: UserModel,
@@ -25,6 +34,7 @@ final class SocialMyCollectionViewModel: ObservableObject {
         initialHasNextFeedPage: Bool = true,
         userService: UserServicing = UserService(),
         diaryService: DiaryServicing = DiaryService(),
+        subscribeService: SubscribeServicing = SubscribeService(),
         onToggleMyPick: @escaping (_ userId: Int, _ isCurrentlyMyPick: Bool) async throws -> Void = { _, _ in }
     ) {
         user = initialUser
@@ -34,6 +44,7 @@ final class SocialMyCollectionViewModel: ObservableObject {
         hasNextFeedPage = initialHasNextFeedPage
         self.userService = userService
         self.diaryService = diaryService
+        self.subscribeService = subscribeService
         self.onToggleMyPick = onToggleMyPick
     }
 
@@ -140,6 +151,53 @@ final class SocialMyCollectionViewModel: ObservableObject {
         }
     }
 
+    func loadConnections(type: ConnectionType) async {
+        connectionRequestID += 1
+        let requestID = connectionRequestID
+        activeConnectionType = type
+        nextConnectionPage = SubscribeService.defaultPage
+        hasNextConnectionPage = true
+        connectionUsers = []
+        connectionErrorMessage = nil
+        isLoadingConnections = true
+        defer { isLoadingConnections = false }
+
+        do {
+            let response = try await fetchConnections(type: type, page: SubscribeService.defaultPage)
+            guard requestID == connectionRequestID else { return }
+            connectionUsers = response.content
+            updateConnectionPaging(from: response)
+        } catch {
+            guard requestID == connectionRequestID else { return }
+            if isRequestCancelled(error) { return }
+            connectionErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func loadMoreConnectionsIfNeeded(currentUserId: Int) async {
+        guard connectionUsers.last?.userId == currentUserId else { return }
+        guard hasNextConnectionPage else { return }
+        guard !isLoadingConnections, !isLoadingMoreConnections else { return }
+        guard let activeConnectionType else { return }
+
+        isLoadingMoreConnections = true
+        defer { isLoadingMoreConnections = false }
+
+        do {
+            let response = try await fetchConnections(type: activeConnectionType, page: nextConnectionPage)
+            appendConnectionUsers(with: response.content)
+            updateConnectionPaging(from: response)
+        } catch {
+            if isRequestCancelled(error) { return }
+            connectionErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func refreshActiveConnections() async {
+        guard let activeConnectionType else { return }
+        await loadConnections(type: activeConnectionType)
+    }
+
     func formattedUpdateDate(from rawUpdateDate: String) -> String {
         let datePart = rawUpdateDate.split(separator: "T").first.map(String.init) ?? rawUpdateDate
         return datePart.replacingOccurrences(of: "-", with: ".")
@@ -151,12 +209,43 @@ final class SocialMyCollectionViewModel: ObservableObject {
         feeds.append(contentsOf: filtered)
     }
 
+    private func appendConnectionUsers(with newUsers: [SubscribeUserModel]) {
+        let existingIDs = Set(connectionUsers.map(\.userId))
+        let filtered = newUsers.filter { !existingIDs.contains($0.userId) }
+        connectionUsers.append(contentsOf: filtered)
+    }
+
     private func updateFeedPaging(from response: UserDiaryFeedsResponse) {
         nextFeedPage = max(response.page.number, 0) + 1
         let totalPages = max(response.page.totalPages, 0)
         let hasNextByPage = nextFeedPage < totalPages
         let hasNextByCount = response.content.count >= DiaryService.defaultSize
         hasNextFeedPage = hasNextByPage || hasNextByCount
+    }
+
+    private func updateConnectionPaging(from response: SubscribeListResponse) {
+        nextConnectionPage = max(response.page.number, 0) + 1
+        let totalPages = max(response.page.totalPages, 0)
+        let hasNextByPage = nextConnectionPage < totalPages
+        let hasNextByCount = response.content.count >= SubscribeService.defaultSize
+        hasNextConnectionPage = hasNextByPage || hasNextByCount
+    }
+
+    private func fetchConnections(type: ConnectionType, page: Int) async throws -> SubscribeListResponse {
+        switch type {
+        case .picks:
+            return try await subscribeService.fetchSubscribes(
+                userId: user.userId,
+                page: page,
+                size: SubscribeService.defaultSize
+            )
+        case .fandom:
+            return try await subscribeService.fetchSubscribers(
+                userId: user.userId,
+                page: page,
+                size: SubscribeService.defaultSize
+            )
+        }
     }
 
     private func resolveErrorMessage(from error: Error) -> String {
@@ -166,6 +255,10 @@ final class SocialMyCollectionViewModel: ObservableObject {
 
         if let diaryError = error as? DiaryServiceError {
             return diaryError.errorDescription ?? "피드 목록을 불러오지 못했어요."
+        }
+
+        if let subscribeError = error as? SubscribeServiceError {
+            return subscribeError.errorDescription ?? "구독 목록을 불러오지 못했어요."
         }
 
         if let apiError = error as? APIClientError {
@@ -186,5 +279,10 @@ final class SocialMyCollectionViewModel: ObservableObject {
 
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    enum ConnectionType {
+        case picks
+        case fandom
     }
 }

--- a/KillingPart/ViewModels/Social/SocialViewModel.swift
+++ b/KillingPart/ViewModels/Social/SocialViewModel.swift
@@ -171,8 +171,12 @@ final class SocialViewModel: ObservableObject {
             resolvedUser = searchedUser
         }
 
+        return makeSocialMyCollectionViewModel(for: resolvedUser)
+    }
+
+    func makeSocialMyCollectionViewModel(for user: UserModel) -> SocialMyCollectionViewModel {
         return SocialMyCollectionViewModel(
-            initialUser: resolvedUser,
+            initialUser: user,
             userService: userService,
             diaryService: diaryService,
             onToggleMyPick: { [self] userId, isCurrentlyMyPick in

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
@@ -17,7 +17,8 @@ struct AddSearchDetailVideoSection: View {
                         YoutubePlayerView(
                             videoURL: video.embedURL,
                             startSeconds: viewModel.startSeconds,
-                            endSeconds: viewModel.endSeconds
+                            endSeconds: viewModel.endSeconds,
+                            playbackFocusToken: playerReloadToken.hashValue
                         )
                             .id(playerReloadToken)
                             .frame(maxWidth: .infinity)

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
@@ -9,6 +9,7 @@ struct YoutubePlayerView: UIViewRepresentable {
     let startSeconds: Double
     let endSeconds: Double
     let isPlaying: Bool
+    let playbackFocusToken: Int
     let shouldLoopPlayback: Bool
     let onPlaybackEnded: (() -> Void)?
 
@@ -17,6 +18,7 @@ struct YoutubePlayerView: UIViewRepresentable {
         startSeconds: Double,
         endSeconds: Double,
         isPlaying: Bool = true,
+        playbackFocusToken: Int = 0,
         shouldLoopPlayback: Bool = true,
         onPlaybackEnded: (() -> Void)? = nil
     ) {
@@ -24,6 +26,7 @@ struct YoutubePlayerView: UIViewRepresentable {
         self.startSeconds = startSeconds
         self.endSeconds = endSeconds
         self.isPlaying = isPlaying
+        self.playbackFocusToken = playbackFocusToken
         self.shouldLoopPlayback = shouldLoopPlayback
         self.onPlaybackEnded = onPlaybackEnded
     }
@@ -87,7 +90,7 @@ struct YoutubePlayerView: UIViewRepresentable {
 
         let targetStart = normalizedSeconds(startSeconds)
         let targetEnd = max(normalizedSeconds(endSeconds), targetStart + 0.1)
-        let preferMutedAutoplay = isPlaying && ProcessInfo.processInfo.isLowPowerModeEnabled
+        let preferMutedAutoplay = false
         if context.coordinator.loadedVideoID != videoID {
             context.coordinator.loadedVideoID = videoID
             context.coordinator.lastSyncedStart = targetStart
@@ -95,6 +98,7 @@ struct YoutubePlayerView: UIViewRepresentable {
             context.coordinator.lastSyncedIsPlaying = isPlaying
             context.coordinator.lastSyncedShouldLoopPlayback = shouldLoopPlayback
             context.coordinator.lastSyncedPreferMutedAutoplay = preferMutedAutoplay
+            context.coordinator.lastSyncedPlaybackFocusToken = playbackFocusToken
             context.coordinator.hasDispatchedEnded = false
             webView.loadHTMLString(
                 makePlayerHTML(
@@ -127,14 +131,24 @@ struct YoutubePlayerView: UIViewRepresentable {
         let isSameMutedAutoplayPreference =
             context.coordinator.lastSyncedPreferMutedAutoplay == preferMutedAutoplay
         let isMutedAutoplayPreferenceChanged = !isSameMutedAutoplayPreference
+        let isSamePlaybackFocusToken =
+            context.coordinator.lastSyncedPlaybackFocusToken == playbackFocusToken
+        let isPlaybackFocusTokenChanged = !isSamePlaybackFocusToken
+
         guard
             isRangeChanged
                 || isPlayStateChanged
                 || isLoopStateChanged
                 || isMutedAutoplayPreferenceChanged
-        else { return }
+                || isPlaybackFocusTokenChanged
+        else {
+            if isPlaying {
+                context.coordinator.kickPlaybackRecoveryIfNeeded(forceSeek: false)
+            }
+            return
+        }
 
-        if isPlayStateChanged && isPlaying {
+        if (isPlayStateChanged || isPlaybackFocusTokenChanged) && isPlaying {
             context.coordinator.hasDispatchedEnded = false
         }
 
@@ -151,6 +165,9 @@ struct YoutubePlayerView: UIViewRepresentable {
         if isPlayStateChanged || isMutedAutoplayPreferenceChanged {
             context.coordinator.lastSyncedPreferMutedAutoplay = preferMutedAutoplay
         }
+        if isPlaybackFocusTokenChanged {
+            context.coordinator.lastSyncedPlaybackFocusToken = playbackFocusToken
+        }
 
         let targetStartJS = jsNumber(targetStart)
         let targetEndJS = jsNumber(targetEnd)
@@ -158,8 +175,8 @@ struct YoutubePlayerView: UIViewRepresentable {
         let shouldLoopPlaybackJS = shouldLoopPlayback ? "true" : "false"
         let preferMutedAutoplayJS = preferMutedAutoplay ? "true" : "false"
         // Keep playback position when only play/pause state changes.
-        // Force seek is only needed when the target range itself changed.
-        let shouldForceSeekJS = isRangeChanged ? "true" : "false"
+        // Force seek is needed when the target range changes or focus returns to this player.
+        let shouldForceSeekJS = (isRangeChanged || (isPlaying && isPlaybackFocusTokenChanged)) ? "true" : "false"
         let playbackControlJS = isPlaying
             ? """
             window.kpHasDispatchedEnded = false;
@@ -179,6 +196,12 @@ struct YoutubePlayerView: UIViewRepresentable {
             }
             if (window.kpApplyDesiredRange) {
                 window.kpApplyDesiredRange(\(shouldForceSeekJS));
+                if (window.kpStartRangeLoop) {
+                    window.kpStartRangeLoop();
+                }
+                if (window.kpResumeAutoplayIfNeeded) {
+                    window.kpResumeAutoplayIfNeeded(\(shouldForceSeekJS));
+                }
                 if (window.kpScheduleAutoplayRetry) {
                     window.kpScheduleAutoplayRetry(\(shouldForceSeekJS));
                 }
@@ -188,10 +211,16 @@ struct YoutubePlayerView: UIViewRepresentable {
                 }
                 window.kpPlayer.playVideo();
             }
+            if (window.kpStartPlaybackWatchdog) {
+                window.kpStartPlaybackWatchdog();
+            }
             """
             : """
             if (window.kpStopAutoplayRetry) {
                 window.kpStopAutoplayRetry();
+            }
+            if (window.kpStopPlaybackWatchdog) {
+                window.kpStopPlaybackWatchdog();
             }
             window.kpAutoplayMutedFallbackActive = false;
             window.kpAutoplayAudioRestoreAttempted = false;
@@ -236,12 +265,16 @@ struct YoutubePlayerView: UIViewRepresentable {
         var lastSyncedIsPlaying: Bool?
         var lastSyncedShouldLoopPlayback: Bool?
         var lastSyncedPreferMutedAutoplay: Bool?
+        var lastSyncedPlaybackFocusToken: Int?
         var redirectURL: URL?
         var openExternalURL: ((URL) -> Void)?
         var onPlaybackEnded: (() -> Void)?
         var hasDispatchedEnded = false
         private var lowPowerModeObserver: NSObjectProtocol?
+        private var didBecomeActiveObserver: NSObjectProtocol?
+        private var willEnterForegroundObserver: NSObjectProtocol?
         private var lastKnownLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+        private var lastPlaybackRecoveryKickAt: TimeInterval = 0
 
         override init() {
             super.init()
@@ -252,11 +285,31 @@ struct YoutubePlayerView: UIViewRepresentable {
             ) { [weak self] _ in
                 self?.handleLowPowerModeChanged()
             }
+            didBecomeActiveObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.handleApplicationDidBecomeActive()
+            }
+            willEnterForegroundObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.willEnterForegroundNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.handleApplicationDidBecomeActive()
+            }
         }
 
         deinit {
             if let lowPowerModeObserver {
                 NotificationCenter.default.removeObserver(lowPowerModeObserver)
+            }
+            if let didBecomeActiveObserver {
+                NotificationCenter.default.removeObserver(didBecomeActiveObserver)
+            }
+            if let willEnterForegroundObserver {
+                NotificationCenter.default.removeObserver(willEnterForegroundObserver)
             }
         }
 
@@ -289,7 +342,8 @@ struct YoutubePlayerView: UIViewRepresentable {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            applyAutoplayPolicyForCurrentPowerMode(forceSeek: false)
+            applyAutoplayPolicyForCurrentPowerMode(forceSeek: true)
+            kickPlaybackRecoveryIfNeeded(forceSeek: false, minimumInterval: 0)
         }
 
         func webView(
@@ -312,12 +366,55 @@ struct YoutubePlayerView: UIViewRepresentable {
             guard isLowPowerModeEnabled != lastKnownLowPowerMode else { return }
             lastKnownLowPowerMode = isLowPowerModeEnabled
             applyAutoplayPolicyForCurrentPowerMode(forceSeek: false)
+            kickPlaybackRecoveryIfNeeded(forceSeek: false, minimumInterval: 0)
+        }
+
+        private func handleApplicationDidBecomeActive() {
+            applyAutoplayPolicyForCurrentPowerMode(forceSeek: true)
+            kickPlaybackRecoveryIfNeeded(forceSeek: true, minimumInterval: 0)
+        }
+
+        func kickPlaybackRecoveryIfNeeded(forceSeek: Bool, minimumInterval: TimeInterval = 0.8) {
+            guard let webView else { return }
+            guard lastSyncedIsPlaying == true else { return }
+
+            let now = CFAbsoluteTimeGetCurrent()
+            guard now - lastPlaybackRecoveryKickAt >= minimumInterval else { return }
+            lastPlaybackRecoveryKickAt = now
+
+            let shouldForceSeekJS = forceSeek ? "true" : "false"
+            webView.evaluateJavaScript(
+                """
+                if (!window.kpShouldAutoplay) {
+                    window.kpShouldAutoplay = true;
+                }
+                if (window.kpSetPreferMutedAutoplay) {
+                    window.kpSetPreferMutedAutoplay(window.kpPreferMutedAutoplay);
+                }
+                if (window.kpStartRangeLoop) {
+                    window.kpStartRangeLoop();
+                }
+                if (window.kpStartPlaybackWatchdog) {
+                    window.kpStartPlaybackWatchdog();
+                }
+                if (window.kpApplyDesiredRange) {
+                    window.kpApplyDesiredRange(\(shouldForceSeekJS));
+                }
+                if (window.kpResumeAutoplayIfNeeded) {
+                    window.kpResumeAutoplayIfNeeded(\(shouldForceSeekJS));
+                }
+                if (window.kpScheduleAutoplayRetry) {
+                    window.kpScheduleAutoplayRetry(false);
+                }
+                """,
+                completionHandler: nil
+            )
         }
 
         private func applyAutoplayPolicyForCurrentPowerMode(forceSeek: Bool) {
             guard let webView, let isPlaying = lastSyncedIsPlaying else { return }
 
-            let preferMutedAutoplay = isPlaying && ProcessInfo.processInfo.isLowPowerModeEnabled
+            let preferMutedAutoplay = false
             lastSyncedPreferMutedAutoplay = preferMutedAutoplay
 
             let shouldAutoplayJS = isPlaying ? "true" : "false"
@@ -341,9 +438,20 @@ struct YoutubePlayerView: UIViewRepresentable {
                         }
                         window.kpPlayer.playVideo();
                     }
+                    if (window.kpStartRangeLoop) {
+                        window.kpStartRangeLoop();
+                    }
+                    if (window.kpResumeAutoplayIfNeeded) {
+                        window.kpResumeAutoplayIfNeeded(\(shouldForceSeekJS));
+                    }
                     if (window.kpScheduleAutoplayRetry) {
                         window.kpScheduleAutoplayRetry(\(shouldForceSeekJS));
                     }
+                    if (window.kpStartPlaybackWatchdog) {
+                        window.kpStartPlaybackWatchdog();
+                    }
+                } else if (window.kpStopPlaybackWatchdog) {
+                    window.kpStopPlaybackWatchdog();
                 }
                 """,
                 completionHandler: nil
@@ -423,6 +531,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                 window.kpPlayer = null;
                 window.kpPlayerReady = false;
                 window.kpLoopTimer = null;
+                window.kpPlaybackWatchdogTimer = null;
                 window.kpAutoplayRetryTimer = null;
                 window.kpAutoplayRetryCount = 0;
                 window.kpAutoplayBaseRetryDelayMs = 220;
@@ -490,15 +599,16 @@ struct YoutubePlayerView: UIViewRepresentable {
                         return;
                     }
 
-                    if (
-                        !window.kpAutoplayMutedFallbackActive
-                        && window.kpPlayer
-                        && window.kpPlayer.unMute
-                    ) {
+                    if (window.kpPlayer && window.kpPlayer.unMute) {
                         window.kpPlayer.unMute();
                     }
-                    if (!window.kpAutoplayMutedFallbackActive) {
-                        window.kpAutoplayAudioRestoreAttempted = false;
+                    window.kpAutoplayAudioRestoreAttempted = false;
+
+                    if (window.kpPlayer && window.kpPlayer.isMuted) {
+                        var isMuted = !!window.kpPlayer.isMuted();
+                        if (!isMuted) {
+                            window.kpAutoplayMutedFallbackActive = false;
+                        }
                     }
                 };
 
@@ -638,6 +748,81 @@ struct YoutubePlayerView: UIViewRepresentable {
                     }, 200);
                 };
 
+                window.kpStopPlaybackWatchdog = function() {
+                    if (window.kpPlaybackWatchdogTimer) {
+                        clearInterval(window.kpPlaybackWatchdogTimer);
+                        window.kpPlaybackWatchdogTimer = null;
+                    }
+                };
+
+                window.kpStartPlaybackWatchdog = function() {
+                    window.kpStopPlaybackWatchdog();
+                    window.kpPlaybackWatchdogTimer = setInterval(function() {
+                        if (!window.kpShouldAutoplay || !window.kpPlayerReady || !window.kpPlayer) {
+                            return;
+                        }
+
+                        var state = Number(window.kpPlayer.getPlayerState ? window.kpPlayer.getPlayerState() : -1);
+                        if (state === 1 || state === 3) {
+                            var isMuted = !!(window.kpPlayer.isMuted && window.kpPlayer.isMuted());
+                            if (!isMuted) {
+                                window.kpAutoplayAudioRestoreAttempted = false;
+                                window.kpAutoplayMutedFallbackActive = false;
+                                return;
+                            }
+
+                            if (window.kpAutoplayAudioRestoreAttempted || !window.kpPlayer.unMute) {
+                                return;
+                            }
+
+                            window.kpAutoplayAudioRestoreAttempted = true;
+                            window.kpPlayer.unMute();
+                            setTimeout(function() {
+                                if (!window.kpShouldAutoplay || !window.kpPlayer) {
+                                    return;
+                                }
+
+                                var stateAfterUnmute = Number(
+                                    window.kpPlayer.getPlayerState
+                                        ? window.kpPlayer.getPlayerState()
+                                        : -1
+                                );
+                                var isMutedAfterUnmute = !!(
+                                    window.kpPlayer.isMuted
+                                    && window.kpPlayer.isMuted()
+                                );
+
+                                if (
+                                    (stateAfterUnmute === 1 || stateAfterUnmute === 3)
+                                    && !isMutedAfterUnmute
+                                ) {
+                                    window.kpAutoplayMutedFallbackActive = false;
+                                    window.kpAutoplayAudioRestoreAttempted = false;
+                                    return;
+                                }
+
+                                window.kpAutoplayAudioRestoreAttempted = false;
+                                if (window.kpAutoplayMutedFallbackActive && window.kpPlayer.mute) {
+                                    window.kpPlayer.mute();
+                                }
+                                if (
+                                    stateAfterUnmute !== 1
+                                    && stateAfterUnmute !== 3
+                                    && window.kpPlayer.playVideo
+                                ) {
+                                    window.kpPlayer.playVideo();
+                                }
+                                if (window.kpResumeAutoplayIfNeeded) {
+                                    window.kpResumeAutoplayIfNeeded(false);
+                                }
+                            }, 180);
+                            return;
+                        }
+
+                        window.kpResumeAutoplayIfNeeded(false);
+                    }, 900);
+                };
+
                 var tag = document.createElement('script');
                 tag.src = 'https://www.youtube.com/iframe_api';
                 document.head.appendChild(tag);
@@ -675,8 +860,10 @@ struct YoutubePlayerView: UIViewRepresentable {
                                 if (window.kpShouldAutoplay) {
                                     window.kpApplyDesiredRange(true);
                                     window.kpStartRangeLoop();
+                                    window.kpStartPlaybackWatchdog();
                                     window.kpResumeAutoplayIfNeeded(true);
                                 } else {
+                                    window.kpStopPlaybackWatchdog();
                                     if (window.kpPlayer.unMute) {
                                         window.kpPlayer.unMute();
                                     }
@@ -693,6 +880,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                                 if (state === 1 || state === 3) {
                                     window.kpHasDispatchedEnded = false;
                                     window.kpStopAutoplayRetry();
+                                    window.kpStartPlaybackWatchdog();
                                     if (
                                         window.kpAutoplayMutedFallbackActive
                                         && !window.kpAutoplayAudioRestoreAttempted
@@ -714,15 +902,29 @@ struct YoutubePlayerView: UIViewRepresentable {
                                                     ? window.kpPlayer.getPlayerState()
                                                     : -1
                                             );
-                                            if (stateAfterUnmute === 1 || stateAfterUnmute === 3) {
+                                            var isMutedAfterUnmute = !!(
+                                                window.kpPlayer.isMuted
+                                                && window.kpPlayer.isMuted()
+                                            );
+                                            if (
+                                                (stateAfterUnmute === 1 || stateAfterUnmute === 3)
+                                                && !isMutedAfterUnmute
+                                            ) {
                                                 window.kpAutoplayMutedFallbackActive = false;
+                                                window.kpAutoplayAudioRestoreAttempted = false;
                                                 return;
                                             }
 
+                                            window.kpAutoplayAudioRestoreAttempted = false;
                                             if (window.kpPlayer.mute) {
                                                 window.kpPlayer.mute();
                                             }
-                                            window.kpPlayer.playVideo();
+                                            if (window.kpPlayer.playVideo) {
+                                                window.kpPlayer.playVideo();
+                                            }
+                                            if (window.kpResumeAutoplayIfNeeded) {
+                                                window.kpResumeAutoplayIfNeeded(false);
+                                            }
                                         }, 160);
                                     }
                                     return;
@@ -748,15 +950,21 @@ struct YoutubePlayerView: UIViewRepresentable {
 
                 document.addEventListener('visibilitychange', function() {
                     if (document.visibilityState === 'visible') {
+                        window.kpStartRangeLoop();
+                        window.kpStartPlaybackWatchdog();
                         window.kpResumeAutoplayIfNeeded(true);
                     }
                 });
 
                 window.addEventListener('pageshow', function() {
+                    window.kpStartRangeLoop();
+                    window.kpStartPlaybackWatchdog();
                     window.kpResumeAutoplayIfNeeded(true);
                 });
 
                 window.addEventListener('focus', function() {
+                    window.kpStartRangeLoop();
+                    window.kpStartPlaybackWatchdog();
                     window.kpResumeAutoplayIfNeeded(false);
                 });
 
@@ -768,6 +976,10 @@ struct YoutubePlayerView: UIViewRepresentable {
                     if (window.kpAutoplayRetryTimer) {
                         clearTimeout(window.kpAutoplayRetryTimer);
                         window.kpAutoplayRetryTimer = null;
+                    }
+                    if (window.kpPlaybackWatchdogTimer) {
+                        clearInterval(window.kpPlaybackWatchdogTimer);
+                        window.kpPlaybackWatchdogTimer = null;
                     }
                 });
             </script>

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
@@ -43,6 +43,7 @@ struct YoutubePlayerView: UIViewRepresentable {
         webView.allowsLinkPreview = false
         webView.navigationDelegate = context.coordinator
         webView.uiDelegate = context.coordinator
+        context.coordinator.attach(webView: webView)
 
         let redirectOverlayButton = UIButton(type: .custom)
         redirectOverlayButton.translatesAutoresizingMaskIntoConstraints = false
@@ -68,6 +69,7 @@ struct YoutubePlayerView: UIViewRepresentable {
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
+        context.coordinator.attach(webView: webView)
         context.coordinator.openExternalURL = { targetURL in
             openURL(targetURL)
         }
@@ -85,12 +87,14 @@ struct YoutubePlayerView: UIViewRepresentable {
 
         let targetStart = normalizedSeconds(startSeconds)
         let targetEnd = max(normalizedSeconds(endSeconds), targetStart + 0.1)
+        let preferMutedAutoplay = isPlaying && ProcessInfo.processInfo.isLowPowerModeEnabled
         if context.coordinator.loadedVideoID != videoID {
             context.coordinator.loadedVideoID = videoID
             context.coordinator.lastSyncedStart = targetStart
             context.coordinator.lastSyncedEnd = targetEnd
             context.coordinator.lastSyncedIsPlaying = isPlaying
             context.coordinator.lastSyncedShouldLoopPlayback = shouldLoopPlayback
+            context.coordinator.lastSyncedPreferMutedAutoplay = preferMutedAutoplay
             context.coordinator.hasDispatchedEnded = false
             webView.loadHTMLString(
                 makePlayerHTML(
@@ -98,7 +102,8 @@ struct YoutubePlayerView: UIViewRepresentable {
                     startSeconds: targetStart,
                     endSeconds: targetEnd,
                     shouldAutoplay: isPlaying,
-                    shouldLoopPlayback: shouldLoopPlayback
+                    shouldLoopPlayback: shouldLoopPlayback,
+                    preferMutedAutoplay: preferMutedAutoplay
                 ),
                 baseURL: appRefererURL
             )
@@ -119,8 +124,16 @@ struct YoutubePlayerView: UIViewRepresentable {
         let isSameLoopState = context.coordinator.lastSyncedShouldLoopPlayback == shouldLoopPlayback
         let isPlayStateChanged = !isSamePlayState
         let isLoopStateChanged = !isSameLoopState
-        guard isRangeChanged || isPlayStateChanged || isLoopStateChanged else { return }
-        
+        let isSameMutedAutoplayPreference =
+            context.coordinator.lastSyncedPreferMutedAutoplay == preferMutedAutoplay
+        let isMutedAutoplayPreferenceChanged = !isSameMutedAutoplayPreference
+        guard
+            isRangeChanged
+                || isPlayStateChanged
+                || isLoopStateChanged
+                || isMutedAutoplayPreferenceChanged
+        else { return }
+
         if isPlayStateChanged && isPlaying {
             context.coordinator.hasDispatchedEnded = false
         }
@@ -135,18 +148,35 @@ struct YoutubePlayerView: UIViewRepresentable {
         if isLoopStateChanged {
             context.coordinator.lastSyncedShouldLoopPlayback = shouldLoopPlayback
         }
+        if isPlayStateChanged || isMutedAutoplayPreferenceChanged {
+            context.coordinator.lastSyncedPreferMutedAutoplay = preferMutedAutoplay
+        }
 
         let targetStartJS = jsNumber(targetStart)
         let targetEndJS = jsNumber(targetEnd)
         let shouldAutoplayJS = isPlaying ? "true" : "false"
         let shouldLoopPlaybackJS = shouldLoopPlayback ? "true" : "false"
+        let preferMutedAutoplayJS = preferMutedAutoplay ? "true" : "false"
         // Keep playback position when only play/pause state changes.
         // Force seek is only needed when the target range itself changed.
         let shouldForceSeekJS = isRangeChanged ? "true" : "false"
         let playbackControlJS = isPlaying
             ? """
             window.kpHasDispatchedEnded = false;
-            window.kpAutoplayAudioRestoreAttempted = false;
+            if (window.kpSetPreferMutedAutoplay) {
+                window.kpSetPreferMutedAutoplay(\(preferMutedAutoplayJS));
+            } else {
+                window.kpPreferMutedAutoplay = \(preferMutedAutoplayJS);
+                if (window.kpPreferMutedAutoplay) {
+                    window.kpAutoplayMutedFallbackActive = true;
+                    window.kpAutoplayAudioRestoreAttempted = false;
+                    if (window.kpPlayer.mute) {
+                        window.kpPlayer.mute();
+                    }
+                } else {
+                    window.kpAutoplayAudioRestoreAttempted = false;
+                }
+            }
             if (window.kpApplyDesiredRange) {
                 window.kpApplyDesiredRange(\(shouldForceSeekJS));
                 if (window.kpScheduleAutoplayRetry) {
@@ -180,6 +210,10 @@ struct YoutubePlayerView: UIViewRepresentable {
             window.kpDesiredEnd = \(targetEndJS);
             window.kpShouldAutoplay = \(shouldAutoplayJS);
             window.kpShouldLoopPlayback = \(shouldLoopPlaybackJS);
+            window.kpPreferMutedAutoplay = \(preferMutedAutoplayJS);
+            if (window.kpSetPreferMutedAutoplay) {
+                window.kpSetPreferMutedAutoplay(window.kpPreferMutedAutoplay);
+            }
             if (window.kpPlayerReady && window.kpPlayer) {
                 \(playbackControlJS)
             }
@@ -195,15 +229,40 @@ struct YoutubePlayerView: UIViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
         static let playbackEventMessageName = "kpPlaybackEvent"
 
+        weak var webView: WKWebView?
         var loadedVideoID: String?
         var lastSyncedStart: Double?
         var lastSyncedEnd: Double?
         var lastSyncedIsPlaying: Bool?
         var lastSyncedShouldLoopPlayback: Bool?
+        var lastSyncedPreferMutedAutoplay: Bool?
         var redirectURL: URL?
         var openExternalURL: ((URL) -> Void)?
         var onPlaybackEnded: (() -> Void)?
         var hasDispatchedEnded = false
+        private var lowPowerModeObserver: NSObjectProtocol?
+        private var lastKnownLowPowerMode = ProcessInfo.processInfo.isLowPowerModeEnabled
+
+        override init() {
+            super.init()
+            lowPowerModeObserver = NotificationCenter.default.addObserver(
+                forName: .NSProcessInfoPowerStateDidChange,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.handleLowPowerModeChanged()
+            }
+        }
+
+        deinit {
+            if let lowPowerModeObserver {
+                NotificationCenter.default.removeObserver(lowPowerModeObserver)
+            }
+        }
+
+        func attach(webView: WKWebView) {
+            self.webView = webView
+        }
 
         @objc
         func handleVideoTap() {
@@ -229,6 +288,10 @@ struct YoutubePlayerView: UIViewRepresentable {
             decisionHandler(.cancel)
         }
 
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            applyAutoplayPolicyForCurrentPowerMode(forceSeek: false)
+        }
+
         func webView(
             _ webView: WKWebView,
             createWebViewWith configuration: WKWebViewConfiguration,
@@ -242,6 +305,49 @@ struct YoutubePlayerView: UIViewRepresentable {
         private func openRedirectURL() {
             guard let redirectURL else { return }
             openExternalURL?(redirectURL)
+        }
+
+        private func handleLowPowerModeChanged() {
+            let isLowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+            guard isLowPowerModeEnabled != lastKnownLowPowerMode else { return }
+            lastKnownLowPowerMode = isLowPowerModeEnabled
+            applyAutoplayPolicyForCurrentPowerMode(forceSeek: false)
+        }
+
+        private func applyAutoplayPolicyForCurrentPowerMode(forceSeek: Bool) {
+            guard let webView, let isPlaying = lastSyncedIsPlaying else { return }
+
+            let preferMutedAutoplay = isPlaying && ProcessInfo.processInfo.isLowPowerModeEnabled
+            lastSyncedPreferMutedAutoplay = preferMutedAutoplay
+
+            let shouldAutoplayJS = isPlaying ? "true" : "false"
+            let preferMutedAutoplayJS = preferMutedAutoplay ? "true" : "false"
+            let shouldForceSeekJS = forceSeek ? "true" : "false"
+
+            webView.evaluateJavaScript(
+                """
+                window.kpShouldAutoplay = \(shouldAutoplayJS);
+                window.kpPreferMutedAutoplay = \(preferMutedAutoplayJS);
+                if (window.kpSetPreferMutedAutoplay) {
+                    window.kpSetPreferMutedAutoplay(\(preferMutedAutoplayJS));
+                }
+                if (\(shouldAutoplayJS) && window.kpPlayerReady && window.kpPlayer) {
+                    window.kpHasDispatchedEnded = false;
+                    if (window.kpApplyDesiredRange) {
+                        window.kpApplyDesiredRange(\(shouldForceSeekJS));
+                    } else {
+                        if (\(shouldForceSeekJS)) {
+                            window.kpPlayer.seekTo(window.kpDesiredStart, true);
+                        }
+                        window.kpPlayer.playVideo();
+                    }
+                    if (window.kpScheduleAutoplayRetry) {
+                        window.kpScheduleAutoplayRetry(\(shouldForceSeekJS));
+                    }
+                }
+                """,
+                completionHandler: nil
+            )
         }
 
         func userContentController(
@@ -271,7 +377,8 @@ struct YoutubePlayerView: UIViewRepresentable {
         startSeconds: Double,
         endSeconds: Double,
         shouldAutoplay: Bool,
-        shouldLoopPlayback: Bool
+        shouldLoopPlayback: Bool,
+        preferMutedAutoplay: Bool
     ) -> String {
         let safeVideoID = escapeForJavaScript(videoID)
         let safeReferer = escapeForJavaScript(appRefererURLString ?? "")
@@ -280,7 +387,9 @@ struct YoutubePlayerView: UIViewRepresentable {
         let initialEndJS = jsNumber(endSeconds)
         let initialShouldAutoplayJS = shouldAutoplay ? "true" : "false"
         let shouldLoopPlaybackJS = shouldLoopPlayback ? "true" : "false"
+        let preferMutedAutoplayJS = preferMutedAutoplay ? "true" : "false"
         let autoplayFlag = shouldAutoplay ? 1 : 0
+        let muteFlag = preferMutedAutoplay ? 1 : 0
 
         return """
         <!doctype html>
@@ -316,10 +425,12 @@ struct YoutubePlayerView: UIViewRepresentable {
                 window.kpLoopTimer = null;
                 window.kpAutoplayRetryTimer = null;
                 window.kpAutoplayRetryCount = 0;
-                window.kpAutoplayMaxRetryCount = 14;
-                window.kpAutoplayRetryDelayMs = 220;
+                window.kpAutoplayBaseRetryDelayMs = 220;
+                window.kpAutoplayRetryBackoffStepMs = 120;
+                window.kpAutoplayRetryMaxDelayMs = 1600;
                 window.kpAutoplayMuteFallbackAfterCount = 3;
-                window.kpAutoplayMutedFallbackActive = false;
+                window.kpPreferMutedAutoplay = \(preferMutedAutoplayJS);
+                window.kpAutoplayMutedFallbackActive = window.kpPreferMutedAutoplay;
                 window.kpAutoplayAudioRestoreAttempted = false;
 
                 window.kpStopAutoplayRetry = function() {
@@ -328,6 +439,67 @@ struct YoutubePlayerView: UIViewRepresentable {
                         window.kpAutoplayRetryTimer = null;
                     }
                     window.kpAutoplayRetryCount = 0;
+                };
+
+                window.kpNextAutoplayRetryDelayMs = function() {
+                    var baseDelay = Number(window.kpAutoplayBaseRetryDelayMs || 220);
+                    var backoffStep = Number(window.kpAutoplayRetryBackoffStepMs || 120);
+                    var maxDelay = Number(window.kpAutoplayRetryMaxDelayMs || 1600);
+                    if (isNaN(baseDelay) || baseDelay < 120) {
+                        baseDelay = 220;
+                    }
+                    if (isNaN(backoffStep) || backoffStep < 0) {
+                        backoffStep = 120;
+                    }
+                    if (isNaN(maxDelay) || maxDelay < baseDelay) {
+                        maxDelay = 1600;
+                    }
+
+                    var retryCount = Number(window.kpAutoplayRetryCount || 0);
+                    if (isNaN(retryCount) || retryCount < 0) {
+                        retryCount = 0;
+                    }
+
+                    var delay = baseDelay + (retryCount * backoffStep);
+                    if (delay > maxDelay) {
+                        delay = maxDelay;
+                    }
+                    return delay;
+                };
+
+                window.kpResumeAutoplayIfNeeded = function(forceSeek) {
+                    if (!window.kpShouldAutoplay || !window.kpPlayerReady || !window.kpPlayer) {
+                        return;
+                    }
+
+                    var state = Number(window.kpPlayer.getPlayerState ? window.kpPlayer.getPlayerState() : -1);
+                    if (state === 1 || state === 3) {
+                        return;
+                    }
+                    window.kpScheduleAutoplayRetry(forceSeek);
+                };
+
+                window.kpSetPreferMutedAutoplay = function(shouldPreferMutedAutoplay) {
+                    window.kpPreferMutedAutoplay = !!shouldPreferMutedAutoplay;
+                    if (window.kpPreferMutedAutoplay) {
+                        window.kpAutoplayMutedFallbackActive = true;
+                        window.kpAutoplayAudioRestoreAttempted = false;
+                        if (window.kpPlayer && window.kpPlayer.mute) {
+                            window.kpPlayer.mute();
+                        }
+                        return;
+                    }
+
+                    if (
+                        !window.kpAutoplayMutedFallbackActive
+                        && window.kpPlayer
+                        && window.kpPlayer.unMute
+                    ) {
+                        window.kpPlayer.unMute();
+                    }
+                    if (!window.kpAutoplayMutedFallbackActive) {
+                        window.kpAutoplayAudioRestoreAttempted = false;
+                    }
                 };
 
                 window.kpDispatchPlaybackEnded = function() {
@@ -376,7 +548,10 @@ struct YoutubePlayerView: UIViewRepresentable {
                         window.kpPlayer.seekTo(targetStart, true);
                     }
 
-                    if (window.kpAutoplayMutedFallbackActive && window.kpPlayer.mute) {
+                    if (
+                        (window.kpPreferMutedAutoplay || window.kpAutoplayMutedFallbackActive)
+                        && window.kpPlayer.mute
+                    ) {
                         window.kpPlayer.mute();
                     }
                     window.kpPlayer.playVideo();
@@ -389,10 +564,8 @@ struct YoutubePlayerView: UIViewRepresentable {
                     if (window.kpAutoplayRetryTimer) {
                         return;
                     }
-                    if (window.kpAutoplayRetryCount >= window.kpAutoplayMaxRetryCount) {
-                        return;
-                    }
 
+                    var retryDelay = window.kpNextAutoplayRetryDelayMs();
                     window.kpAutoplayRetryTimer = setTimeout(function() {
                         window.kpAutoplayRetryTimer = null;
                         if (!window.kpShouldAutoplay || !window.kpPlayerReady || !window.kpPlayer) {
@@ -407,7 +580,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                             return;
                         }
 
-                        window.kpAutoplayRetryCount += 1;
+                        window.kpAutoplayRetryCount = Math.min(window.kpAutoplayRetryCount + 1, 20);
                         if (
                             !window.kpAutoplayMutedFallbackActive
                             && window.kpAutoplayRetryCount >= window.kpAutoplayMuteFallbackAfterCount
@@ -416,7 +589,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                             window.kpAutoplayAudioRestoreAttempted = false;
                         }
                         window.kpScheduleAutoplayRetry(false);
-                    }, window.kpAutoplayRetryDelayMs);
+                    }, retryDelay);
                 };
 
                 window.kpStartRangeLoop = function() {
@@ -460,7 +633,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                         }
 
                         if (state === 0 || state === 2 || state === 5 || state === -1) {
-                            window.kpScheduleAutoplayRetry(false);
+                            window.kpResumeAutoplayIfNeeded(false);
                         }
                     }, 200);
                 };
@@ -476,6 +649,7 @@ struct YoutubePlayerView: UIViewRepresentable {
                         videoId: '\(safeVideoID)',
                         playerVars: {
                             autoplay: \(autoplayFlag),
+                            mute: \(muteFlag),
                             controls: 1,
                             disablekb: 0,
                             fs: 1,
@@ -490,12 +664,18 @@ struct YoutubePlayerView: UIViewRepresentable {
                         events: {
                             onReady: function() {
                                 window.kpPlayerReady = true;
-                                window.kpAutoplayMutedFallbackActive = false;
-                                window.kpAutoplayAudioRestoreAttempted = false;
+                                var iframe = window.kpPlayer.getIframe ? window.kpPlayer.getIframe() : null;
+                                if (iframe) {
+                                    iframe.setAttribute(
+                                        'allow',
+                                        'autoplay; encrypted-media; fullscreen; picture-in-picture'
+                                    );
+                                }
+                                window.kpSetPreferMutedAutoplay(window.kpPreferMutedAutoplay);
                                 if (window.kpShouldAutoplay) {
                                     window.kpApplyDesiredRange(true);
                                     window.kpStartRangeLoop();
-                                    window.kpScheduleAutoplayRetry(true);
+                                    window.kpResumeAutoplayIfNeeded(true);
                                 } else {
                                     if (window.kpPlayer.unMute) {
                                         window.kpPlayer.unMute();
@@ -559,12 +739,26 @@ struct YoutubePlayerView: UIViewRepresentable {
                                 }
 
                                 if (state === 2 || state === 5 || state === -1) {
-                                    window.kpScheduleAutoplayRetry(false);
+                                    window.kpResumeAutoplayIfNeeded(false);
                                 }
                             }
                         }
                     });
                 };
+
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') {
+                        window.kpResumeAutoplayIfNeeded(true);
+                    }
+                });
+
+                window.addEventListener('pageshow', function() {
+                    window.kpResumeAutoplayIfNeeded(true);
+                });
+
+                window.addEventListener('focus', function() {
+                    window.kpResumeAutoplayIfNeeded(false);
+                });
 
                 window.addEventListener('beforeunload', function() {
                     if (window.kpLoopTimer) {

--- a/KillingPart/Views/Screens/Main/MainTabView.swift
+++ b/KillingPart/Views/Screens/Main/MainTabView.swift
@@ -6,7 +6,10 @@ struct MainTabView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            MyTabView(onLogout: onLogout)
+            MyTabView(
+                onLogout: onLogout,
+                isRootTabSelected: selectedTab == .my
+            )
                 .tabItem {
                     Label("MY", systemImage: "house")
                 }
@@ -19,7 +22,7 @@ struct MainTabView: View {
                 }
                 .tag(MainRootTab.add)
             
-            SocialView()
+            SocialView(isRootTabSelected: selectedTab == .social)
                 .tabItem {
                     Label("소셜", systemImage: "person.2")
                 }

--- a/KillingPart/Views/Screens/Main/My/MyCollection/Components/FeedCard/MyCollectionFeedCard.swift
+++ b/KillingPart/Views/Screens/Main/My/MyCollection/Components/FeedCard/MyCollectionFeedCard.swift
@@ -3,11 +3,29 @@ import SwiftUI
 struct MyCollectionFeedCard: View {
     let feed: DiaryFeedModel
     let formattedUpdateDate: String
+    let onLikeLongPress: () -> Void
+
+    init(
+        feed: DiaryFeedModel,
+        formattedUpdateDate: String,
+        onLikeLongPress: @escaping () -> Void = {}
+    ) {
+        self.feed = feed
+        self.formattedUpdateDate = formattedUpdateDate
+        self.onLikeLongPress = onLikeLongPress
+    }
 
     var body: some View {
         VStack(alignment: .center, spacing: AppSpacing.xs) {
             HStack {
                 MyCollectionFeedLikeBadgeView(isLiked: feed.isLiked, likeCount: feed.likeCount)
+                    .contentShape(Rectangle())
+                    .highPriorityGesture(
+                        LongPressGesture(minimumDuration: 0.45)
+                            .onEnded { _ in
+                                onLikeLongPress()
+                            }
+                    )
                 Spacer()
                 MyCollectionFeedScopeBadgeView(scope: feed.scope)
             }

--- a/KillingPart/Views/Screens/Main/My/MyCollection/Components/ProfileCard/MyCollectionProfileCard.swift
+++ b/KillingPart/Views/Screens/Main/My/MyCollection/Components/ProfileCard/MyCollectionProfileCard.swift
@@ -7,6 +7,8 @@ struct MyCollectionProfileCard: View {
     let killingPartStatText: String
     let fanStatText: String
     let pickStatText: String
+    let onFanStatTap: () -> Void
+    let onPickStatTap: () -> Void
     let onEditProfileTap: () -> Void
 
     var body: some View {
@@ -35,8 +37,15 @@ struct MyCollectionProfileCard: View {
 
                         HStack(alignment: .center, spacing: AppSpacing.m) {
                             MyCollectionProfileStatItemView(value: killingPartStatText, title: "킬링파트")
-                            MyCollectionProfileStatItemView(value: fanStatText, title: "팬덤")
-                            MyCollectionProfileStatItemView(value: pickStatText, title: "PICKS")
+                            Button(action: onFanStatTap) {
+                                MyCollectionProfileStatItemView(value: fanStatText, title: "팬덤")
+                            }
+                            .buttonStyle(.plain)
+
+                            Button(action: onPickStatTap) {
+                                MyCollectionProfileStatItemView(value: pickStatText, title: "PICKS")
+                            }
+                            .buttonStyle(.plain)
                         }
                         .frame(maxWidth: .infinity, alignment: .center)
                     }

--- a/KillingPart/Views/Screens/Main/My/MyCollection/MyCollectionView.swift
+++ b/KillingPart/Views/Screens/Main/My/MyCollection/MyCollectionView.swift
@@ -9,19 +9,27 @@ struct MyCollectionView: View {
     @State private var navigationDirection: MyCollectionScreenTransitionDirection = .forward
     @State private var isAccountActionDialogPresented = false
     @State private var collectionListRenderID = UUID()
+    @State private var activeConnectionSheet: ConnectionSheetType?
+    @State private var activeLikeUsersSheet: LikeUsersSheetContext?
+    @State private var pendingNavigationUser: UserModel?
+    @State private var selectedNavigationUser: UserModel?
+    @State private var isUserCollectionNavigationActive = false
+    @State private var likeUsersSearchText = ""
 
     init(
         onSessionEnded: @escaping () -> Void,
         authenticationService: AuthenticationServicing = AuthenticationService(),
         userService: UserServicing = UserService(),
-        diaryService: DiaryServicing = DiaryService()
+        diaryService: DiaryServicing = DiaryService(),
+        subscribeService: SubscribeServicing = SubscribeService()
     ) {
         self.onSessionEnded = onSessionEnded
         _viewModel = StateObject(
             wrappedValue: MyCollectionViewModel(
                 authenticationService: authenticationService,
                 userService: userService,
-                diaryService: diaryService
+                diaryService: diaryService,
+                subscribeService: subscribeService
             )
         )
         _profileSettingViewModel = StateObject(
@@ -86,6 +94,95 @@ struct MyCollectionView: View {
                 }
             }
         }
+        .onChange(of: activeConnectionSheet) { sheetType in
+            guard sheetType == nil, let pendingNavigationUser else { return }
+            self.pendingNavigationUser = nil
+            selectedNavigationUser = pendingNavigationUser
+            DispatchQueue.main.async {
+                isUserCollectionNavigationActive = true
+            }
+        }
+        .onChange(of: activeLikeUsersSheet) { sheetContext in
+            if sheetContext == nil {
+                viewModel.clearLikeUsersState()
+                likeUsersSearchText = ""
+                guard let pendingNavigationUser else { return }
+                self.pendingNavigationUser = nil
+                selectedNavigationUser = pendingNavigationUser
+                DispatchQueue.main.async {
+                    isUserCollectionNavigationActive = true
+                }
+            }
+        }
+        .onChange(of: isUserCollectionNavigationActive) { isActive in
+            if !isActive {
+                selectedNavigationUser = nil
+            }
+        }
+        .sheet(item: $activeConnectionSheet) { sheetType in
+            MyCollectionConnectionListSheet(
+                title: sheetType.title,
+                users: viewModel.connectionUsers,
+                isLoading: viewModel.isLoadingConnections,
+                isLoadingMore: viewModel.isLoadingMoreConnections,
+                errorMessage: viewModel.connectionErrorMessage,
+                emptyMessage: sheetType.emptyMessage,
+                onRetry: {
+                    Task {
+                        await viewModel.refreshActiveConnections()
+                    }
+                },
+                onUserAppear: { userId in
+                    Task {
+                        await viewModel.loadMoreConnectionsIfNeeded(currentUserId: userId)
+                    }
+                },
+                onUserTap: { user in
+                    pendingNavigationUser = UserModel(from: user)
+                    activeConnectionSheet = nil
+                }
+            )
+        }
+        .sheet(item: $activeLikeUsersSheet) { sheetContext in
+            SocialDiaryLikeUsersSheet(
+                title: "좋아요한 사용자",
+                searchText: $likeUsersSearchText,
+                users: viewModel.likeUsers,
+                isLoading: viewModel.isLoadingLikeUsers,
+                isLoadingMore: viewModel.isLoadingMoreLikeUsers,
+                errorMessage: viewModel.likeUsersErrorMessage,
+                emptyMessage: "좋아요를 누른 사용자가 아직 없어요.",
+                onSearchSubmit: {
+                    Task {
+                        await viewModel.loadLikeUsers(
+                            diaryId: sheetContext.diaryId,
+                            searchCond: normalizedLikeUsersSearchCond
+                        )
+                    }
+                },
+                onSearchClear: {
+                    likeUsersSearchText = ""
+                    Task {
+                        await viewModel.loadLikeUsers(diaryId: sheetContext.diaryId, searchCond: nil)
+                    }
+                },
+                onRetry: {
+                    Task {
+                        await viewModel.retryLikeUsersLoading()
+                    }
+                },
+                onUserAppear: { userId in
+                    Task {
+                        await viewModel.loadMoreLikeUsersIfNeeded(currentUserId: userId)
+                    }
+                },
+                onUserTap: { user in
+                    pendingNavigationUser = user
+                    activeLikeUsersSheet = nil
+                }
+            )
+        }
+        .background(userCollectionNavigationLink)
     }
 
     private var screenTransition: AnyTransition {
@@ -121,7 +218,14 @@ struct MyCollectionView: View {
                             ) {
                                 MyCollectionFeedCard(
                                     feed: feed,
-                                    formattedUpdateDate: viewModel.formattedUpdateDate(from: feed.updateDate)
+                                    formattedUpdateDate: viewModel.formattedUpdateDate(from: feed.updateDate),
+                                    onLikeLongPress: {
+                                        likeUsersSearchText = ""
+                                        activeLikeUsersSheet = LikeUsersSheetContext(diaryId: feed.diaryId)
+                                        Task {
+                                            await viewModel.loadLikeUsers(diaryId: feed.diaryId, searchCond: nil)
+                                        }
+                                    }
                                 )
                             }
                             .buttonStyle(.plain)
@@ -196,7 +300,13 @@ struct MyCollectionView: View {
             profileImageURL: viewModel.profileImageURL,
             killingPartStatText: viewModel.killingPartStatText,
             fanStatText: viewModel.fanStatText,
-            pickStatText: viewModel.pickStatText
+            pickStatText: viewModel.pickStatText,
+            onFanStatTap: {
+                presentConnectionSheet(.fandom)
+            },
+            onPickStatTap: {
+                presentConnectionSheet(.picks)
+            }
         ) {
             profileSettingViewModel.syncUser(viewModel.user)
             navigationDirection = .forward
@@ -221,6 +331,158 @@ struct MyCollectionView: View {
             viewModel.applyUpdatedUser(updatedUser)
             profileSettingViewModel.syncUser(updatedUser)
         }
+    }
+
+    private var normalizedLikeUsersSearchCond: String? {
+        let trimmed = likeUsersSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var userCollectionNavigationLink: some View {
+        NavigationLink(
+            isActive: $isUserCollectionNavigationActive,
+            destination: {
+                if let selectedNavigationUser {
+                    SocialMyCollectionView(
+                        viewModel: viewModel.makeSocialMyCollectionViewModel(for: selectedNavigationUser)
+                    )
+                    .id(selectedNavigationUser.userId)
+                } else {
+                    EmptyView()
+                }
+            },
+            label: {
+                EmptyView()
+            }
+        )
+        .hidden()
+    }
+
+    private func presentConnectionSheet(_ sheetType: ConnectionSheetType) {
+        activeConnectionSheet = sheetType
+        Task {
+            await viewModel.loadConnections(type: sheetType.connectionType)
+        }
+    }
+
+    private enum ConnectionSheetType: String, Identifiable {
+        case picks
+        case fandom
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .picks:
+                return "PICKS"
+            case .fandom:
+                return "팬덤"
+            }
+        }
+
+        var emptyMessage: String {
+            switch self {
+            case .picks:
+                return "표시할 PICKS가 없어요."
+            case .fandom:
+                return "표시할 팬덤이 없어요."
+            }
+        }
+
+        var connectionType: MyCollectionViewModel.ConnectionType {
+            switch self {
+            case .picks:
+                return .picks
+            case .fandom:
+                return .fandom
+            }
+        }
+    }
+
+    private struct LikeUsersSheetContext: Identifiable, Equatable {
+        let diaryId: Int
+        var id: Int { diaryId }
+    }
+}
+
+private struct MyCollectionConnectionListSheet: View {
+    let title: String
+    let users: [SubscribeUserModel]
+    let isLoading: Bool
+    let isLoadingMore: Bool
+    let errorMessage: String?
+    let emptyMessage: String
+    let onRetry: () -> Void
+    let onUserAppear: (Int) -> Void
+    let onUserTap: (SubscribeUserModel) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.m) {
+            Text(title)
+                .font(AppFont.paperlogy6SemiBold(size: 16))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if isLoading && users.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .tint(AppColors.primary600)
+                    Spacer()
+                }
+                .padding(.top, AppSpacing.xl)
+            } else if let errorMessage, users.isEmpty {
+                VStack(spacing: AppSpacing.s) {
+                    Text(errorMessage)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(Color.white.opacity(0.8))
+                        .multilineTextAlignment(.center)
+
+                    Button("다시 시도") {
+                        onRetry()
+                    }
+                    .font(AppFont.paperlogy5Medium(size: 13))
+                    .foregroundStyle(AppColors.primary600)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, AppSpacing.xl)
+            } else if users.isEmpty {
+                Text(emptyMessage)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(Color.white.opacity(0.72))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, AppSpacing.xl)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: AppSpacing.s) {
+                        ForEach(users) { user in
+                            Button {
+                                onUserTap(user)
+                            } label: {
+                                SocialFriendRowView(user: .subscribed(user))
+                            }
+                            .buttonStyle(.plain)
+                            .onAppear {
+                                onUserAppear(user.userId)
+                            }
+                        }
+
+                        if isLoadingMore {
+                            ProgressView()
+                                .tint(AppColors.primary600)
+                                .padding(.top, AppSpacing.s)
+                        }
+                    }
+                    .padding(.bottom, AppSpacing.m)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.m)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/KillingPart/Views/Screens/Main/My/MyCollection/[diaryId]/components/MyCollectionDiaryVideoSection.swift
+++ b/KillingPart/Views/Screens/Main/My/MyCollection/[diaryId]/components/MyCollectionDiaryVideoSection.swift
@@ -13,7 +13,8 @@ struct MyCollectionDiaryVideoSection: View {
         YoutubePlayerView(
             videoURL: videoURL,
             startSeconds: startSeconds,
-            endSeconds: endSeconds
+            endSeconds: endSeconds,
+            playbackFocusToken: playerReloadToken.hashValue
         )
         .id(playerReloadToken)
         .frame(maxWidth: .infinity)

--- a/KillingPart/Views/Screens/Main/My/MyTabView.swift
+++ b/KillingPart/Views/Screens/Main/My/MyTabView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct MyTabView: View {
     let onLogout: () -> Void
+    let isRootTabSelected: Bool
     @State private var selectedTab: MyTopTab = .playKillingPart
     @State private var tabTransitionDirection: Edge = .trailing
     private static var hasConfiguredSegmentedControlAppearance = false
@@ -33,7 +34,9 @@ struct MyTabView: View {
                                 MyCollectionView(onSessionEnded: onLogout)
                                     .transition(tabContentTransition)
                             } else if selectedTab == .playKillingPart {
-                                PlayKillingPartView()
+                                PlayKillingPartView(
+                                    isParentActive: isRootTabSelected && selectedTab == .playKillingPart
+                                )
                                     .transition(tabContentTransition)
                             } else {
                                 MusicCalendarView()
@@ -151,7 +154,10 @@ private enum MyTopTab: CaseIterable {
 
 
 #Preview {
-    MyTabView(onLogout: {
-        print("로그아웃")
-    })
+    MyTabView(
+        onLogout: {
+            print("로그아웃")
+        },
+        isRootTabSelected: true
+    )
 }

--- a/KillingPart/Views/Screens/Main/My/PlayKillingPart/PlayKillingPartView.swift
+++ b/KillingPart/Views/Screens/Main/My/PlayKillingPart/PlayKillingPartView.swift
@@ -3,6 +3,7 @@ import UniformTypeIdentifiers
 import UIKit
 
 struct PlayKillingPartView: View {
+    let isParentActive: Bool
     @Environment(\.scenePhase) private var scenePhase
 
     @StateObject private var viewModel: MyCollectionViewModel
@@ -17,6 +18,7 @@ struct PlayKillingPartView: View {
     @State private var hasCompletedInitialLoad = false
     @State private var lastTickDate = Date()
     @State private var playerReloadToken = UUID()
+    @State private var playbackFocusToken = 0
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
     private let controlsHeight: CGFloat = 98
@@ -24,10 +26,12 @@ struct PlayKillingPartView: View {
     private let reorderAnimationDuration: Double = 0.24
 
     init(
+        isParentActive: Bool = true,
         authenticationService: AuthenticationServicing = AuthenticationService(),
         userService: UserServicing = UserService(),
         diaryService: DiaryServicing = DiaryService()
     ) {
+        self.isParentActive = isParentActive
         _viewModel = StateObject(
             wrappedValue: MyCollectionViewModel(
                 authenticationService: authenticationService,
@@ -56,6 +60,7 @@ struct PlayKillingPartView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
             resetTickReference()
+            bumpPlaybackFocusToken()
             Task {
                 let refetchResult = await refreshPlaybackFeeds()
                 hasCompletedInitialLoad = true
@@ -86,9 +91,21 @@ struct PlayKillingPartView: View {
             synchronizeSelectedTrackIfNeeded()
         }
         .onChange(of: scenePhase) { phase in
-            if phase == .active {
+            if phase == .active && isParentActive {
                 elapsedInCurrentRange = 0
                 playerReloadToken = UUID()
+                bumpPlaybackFocusToken()
+            }
+            resetTickReference()
+        }
+        .onChange(of: isParentActive) { isParentActive in
+            if isParentActive {
+                elapsedInCurrentRange = 0
+                if currentTrack != nil {
+                    isPlaying = true
+                }
+                playerReloadToken = UUID()
+                bumpPlaybackFocusToken()
             }
             resetTickReference()
         }
@@ -113,6 +130,7 @@ struct PlayKillingPartView: View {
                 PlayKillingPartCurrentTrackContent(
                     track: currentTrack,
                     isPlaying: isPlaying,
+                    playbackFocusToken: playbackFocusToken,
                     playerReloadToken: playerReloadToken
                 )
             } else if hasCompletedInitialLoad {
@@ -415,6 +433,9 @@ struct PlayKillingPartView: View {
         guard currentTrack != nil else { return }
         guard !playViewModel.isEditMode else { return }
         isPlaying.toggle()
+        if isPlaying {
+            bumpPlaybackFocusToken()
+        }
         resetTickReference()
     }
 
@@ -445,8 +466,10 @@ struct PlayKillingPartView: View {
         }
 
         selectedTrackID = selectedTrack.id
+        isPlaying = true
         elapsedInCurrentRange = 0
         playerReloadToken = UUID()
+        bumpPlaybackFocusToken()
         resetTickReference()
     }
 
@@ -460,6 +483,7 @@ struct PlayKillingPartView: View {
 
         if !isPlaying {
             isPlaying = true
+            bumpPlaybackFocusToken()
         }
 
         if
@@ -475,6 +499,7 @@ struct PlayKillingPartView: View {
         selectedTrackID = playlistTracks[0].id
         elapsedInCurrentRange = 0
         playerReloadToken = UUID()
+        bumpPlaybackFocusToken()
         resetTickReference()
     }
 
@@ -483,6 +508,7 @@ struct PlayKillingPartView: View {
             lastTickDate = now
         }
 
+        guard isPlaybackActive else { return }
         guard isPlaying else { return }
         guard let currentTrack else { return }
 
@@ -501,6 +527,14 @@ struct PlayKillingPartView: View {
 
     private func resetTickReference() {
         lastTickDate = Date()
+    }
+
+    private var isPlaybackActive: Bool {
+        isParentActive && scenePhase == .active
+    }
+
+    private func bumpPlaybackFocusToken() {
+        playbackFocusToken &+= 1
     }
 
     private func refreshPlaybackFeeds() async -> PlaybackFeedRefetchResult {
@@ -525,6 +559,7 @@ struct PlayKillingPartView: View {
         elapsedInCurrentRange = 0
         isPlaying = true
         playerReloadToken = UUID()
+        bumpPlaybackFocusToken()
         resetTickReference()
     }
 

--- a/KillingPart/Views/Screens/Main/My/PlayKillingPart/components/PlayKillingPartCurrentTrackContent.swift
+++ b/KillingPart/Views/Screens/Main/My/PlayKillingPart/components/PlayKillingPartCurrentTrackContent.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PlayKillingPartCurrentTrackContent: View {
     let track: PlayKillingPartTrack
     let isPlaying: Bool
+    let playbackFocusToken: Int
     let playerReloadToken: UUID
 
     private let videoAspectRatio: CGFloat = 16 / 9
@@ -16,7 +17,8 @@ struct PlayKillingPartCurrentTrackContent: View {
                         videoURL: videoURL,
                         startSeconds: track.startSeconds,
                         endSeconds: track.endSeconds,
-                        isPlaying: isPlaying
+                        isPlaying: isPlaying,
+                        playbackFocusToken: playbackFocusToken
                     )
                     .id("\(track.id)-\(playerReloadToken)")
                     .frame(maxWidth: .infinity)

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialDiaryReportSheet.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialDiaryReportSheet.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct SocialDiaryReportSheet: View {
+    @Binding var reportReason: String
+    let isSubmitting: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onSubmit: () -> Void
+    @FocusState private var isReasonFocused: Bool
+
+    private let maxReportLength = 200
+
+    var body: some View {
+        VStack(spacing: AppSpacing.m) {
+            Text("불편하거나, 부적절한 콘텐츠를 발견하셨나요?\n아래에 신고 사유를 작성해주세요.")
+                .font(AppFont.paperlogy5Medium(size: 14))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            reportReasonEditor
+
+            if let errorMessage, !errorMessage.isEmpty {
+                Text(errorMessage)
+                    .font(AppFont.paperlogy4Regular(size: 12))
+                    .foregroundStyle(Color(hex: "#FF5A5A"))
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            actionButtons
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.l)
+        .padding(.bottom, AppSpacing.m)
+        .presentationDetents([.height(460), .large])
+        .presentationDragIndicator(.visible)
+        .interactiveDismissDisabled(isSubmitting)
+        .preferredColorScheme(.dark)
+        .onChange(of: reportReason) { newValue in
+            if newValue.count > maxReportLength {
+                reportReason = String(newValue.prefix(maxReportLength))
+            }
+        }
+    }
+
+    private var reportReasonEditor: some View {
+        VStack(alignment: .trailing, spacing: AppSpacing.xs) {
+            ZStack(alignment: .topLeading) {
+                if reportReason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("신고 사유를 입력해주세요.")
+                        .font(AppFont.paperlogy4Regular(size: 14))
+                        .foregroundStyle(Color.white.opacity(0.4))
+                        .padding(.horizontal, AppSpacing.s)
+                        .padding(.vertical, AppSpacing.s)
+                }
+
+                TextEditor(text: $reportReason)
+                    .font(AppFont.paperlogy4Regular(size: 14))
+                    .foregroundColor(.white)
+                    .scrollContentBackground(.hidden)
+                    .focused($isReasonFocused)
+                    .padding(.horizontal, AppSpacing.xs)
+                    .padding(.vertical, AppSpacing.xs)
+                    .frame(minHeight: 180)
+            }
+            .background(Color.white.opacity(0.07))
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
+            }
+
+            Text("\(reportReason.count)/\(maxReportLength)")
+                .font(AppFont.paperlogy4Regular(size: 11))
+                .foregroundStyle(Color.white.opacity(0.6))
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: AppSpacing.s) {
+            Button {
+                isReasonFocused = false
+                onCancel()
+            } label: {
+                Text("돌아가기")
+                    .font(AppFont.paperlogy5Medium(size: 14))
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+                    .background(Color.white, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(isSubmitting)
+            .opacity(isSubmitting ? 0.72 : 1)
+
+            Button {
+                isReasonFocused = false
+                onSubmit()
+            } label: {
+                Group {
+                    if isSubmitting {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Text("신고하기")
+                            .font(AppFont.paperlogy5Medium(size: 14))
+                    }
+                }
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 48)
+                .background(Color(hex: "#FF5A5A"), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .disabled(isSubmitting)
+            .opacity(isSubmitting ? 0.72 : 1)
+        }
+    }
+}

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -10,6 +10,7 @@ struct SocialFeedPageCardView: View {
     let onLikeTap: () -> Void
     let onLikeLongPress: () -> Void
     let onStoreTap: () -> Void
+    let onReportTap: () -> Void
     let onVideoPlaybackEnded: () -> Void
     @State private var shouldIgnoreNextLikeTap = false
 
@@ -22,7 +23,23 @@ struct SocialFeedPageCardView: View {
                             SocialFeedProfileView(feed: feed)
                         }
                         .buttonStyle(.plain)
+
                         Spacer()
+
+                        Menu {
+                            Button {
+                                onReportTap()
+                            } label: {
+                                Label("신고하기", systemImage: "exclamationmark.triangle.fill")
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis")
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(.white.opacity(0.9))
+                                .frame(width: 32, height: 32)
+                                .background(Color.white.opacity(0.1), in: Circle())
+                        }
+                        .buttonStyle(.plain)
                     }
 
                     HStack(alignment: .top, spacing: AppSpacing.s) {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -6,6 +6,7 @@ struct SocialFeedPageCardView: View {
     let playbackFocusToken: Int
     let elapsedInCurrentRange: TimeInterval
     let shouldLoadPlayer: Bool
+    let onProfileTap: () -> Void
     let onLikeTap: () -> Void
     let onStoreTap: () -> Void
     let onVideoPlaybackEnded: () -> Void
@@ -15,7 +16,10 @@ struct SocialFeedPageCardView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: AppSpacing.s) {
                     HStack {
-                        SocialFeedProfileView(feed: feed)
+                        Button(action: onProfileTap) {
+                            SocialFeedProfileView(feed: feed)
+                        }
+                        .buttonStyle(.plain)
                         Spacer()
                     }
 

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -16,124 +16,112 @@ struct SocialFeedPageCardView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: AppSpacing.s) {
-                    HStack {
-                        Button(action: onProfileTap) {
-                            SocialFeedProfileView(feed: feed)
-                        }
-                        .buttonStyle(.plain)
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                HStack {
+                    Button(action: onProfileTap) {
+                        SocialFeedProfileView(feed: feed)
+                    }
+                    .buttonStyle(.plain)
 
-                        Spacer()
+                    Spacer()
 
-                        Menu {
-                            Button {
-                                onReportTap()
-                            } label: {
-                                Label {
-                                    Text("신고하기")
-                                } icon: {
-                                    Image(systemName: "light.beacon.max")
-                                }
-                                .tint(.red)
-                            }
+                    Menu {
+                        Button {
+                            onReportTap()
                         } label: {
-                            Image(systemName: "ellipsis")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.white.opacity(0.9))
-                                .frame(width: 32, height: 32)
-                                .background(Color.white.opacity(0.1), in: Circle())
+                            Label {
+                                Text("신고하기")
+                            } icon: {
+                                Image(systemName: "light.beacon.max")
+                            }
+                            .tint(.red)
                         }
-                        .buttonStyle(.plain)
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(.white.opacity(0.9))
+                            .frame(width: 32, height: 32)
+                            .background(Color.white.opacity(0.1), in: Circle())
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                HStack(alignment: .top, spacing: AppSpacing.s) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(feed.musicTitle)
+                            .font(AppFont.paperlogy6SemiBold(size: 16))
+                            .foregroundStyle(.white)
+                            .lineLimit(2)
+
+                        Text(feed.artist)
+                            .font(AppFont.paperlogy4Regular(size: 14))
+                            .foregroundStyle(.white.opacity(0.8))
+                            .lineLimit(2)
                     }
 
-                    HStack(alignment: .top, spacing: AppSpacing.s) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(feed.musicTitle)
-                                .font(AppFont.paperlogy6SemiBold(size: 16))
-                                .foregroundStyle(.white)
-                                .lineLimit(2)
+                    Spacer(minLength: 0)
 
-                            Text(feed.artist)
-                                .font(AppFont.paperlogy4Regular(size: 14))
-                                .foregroundStyle(.white.opacity(0.8))
-                                .lineLimit(2)
-                        }
-
-                        Spacer(minLength: 0)
-
-                        HStack(spacing: AppSpacing.s) {
-                            HStack(spacing: 4) {
-                                Button {
-                                    if shouldIgnoreNextLikeTap {
-                                        shouldIgnoreNextLikeTap = false
-                                        return
-                                    }
-                                    onLikeTap()
-                                } label: {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: feed.isLiked ? "heart.fill" : "heart")
-                                            .foregroundStyle(feed.isLiked ? Color.kpPrimary : .white.opacity(0.75))
-                                        Text(feed.likeCount.formatted())
-                                            .font(AppFont.paperlogy4Regular(size: 12))
-                                            .foregroundStyle(.white.opacity(0.85))
-                                    }
-                                    .padding(.horizontal, AppSpacing.xs)
-                                    .padding(.vertical, 6)
-                                    .background(Color.white.opacity(0.1), in: Capsule())
-                                }
-                                .buttonStyle(.plain)
-                                .simultaneousGesture(
-                                    LongPressGesture(minimumDuration: 0.45)
-                                        .onEnded { _ in
-                                            shouldIgnoreNextLikeTap = true
-                                            onLikeLongPress()
-                                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                                shouldIgnoreNextLikeTap = false
-                                            }
-                                        }
-                                )
-                            }
-
+                    HStack(spacing: AppSpacing.s) {
+                        HStack(spacing: 4) {
                             Button {
-                                onStoreTap()
+                                if shouldIgnoreNextLikeTap {
+                                    shouldIgnoreNextLikeTap = false
+                                    return
+                                }
+                                onLikeTap()
                             } label: {
-                                Image(systemName: feed.isStored ? "bookmark.fill" : "bookmark")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(AppColors.primary600)
-                                    .padding(.horizontal, AppSpacing.xs)
-                                    .padding(.vertical, 6)
-                                    .background(Color.white.opacity(0.1), in: Capsule())
+                                HStack(spacing: 4) {
+                                    Image(systemName: feed.isLiked ? "heart.fill" : "heart")
+                                        .foregroundStyle(feed.isLiked ? Color.kpPrimary : .white.opacity(0.75))
+                                    Text(feed.likeCount.formatted())
+                                        .font(AppFont.paperlogy4Regular(size: 12))
+                                        .foregroundStyle(.white.opacity(0.85))
+                                }
+                                .padding(.horizontal, AppSpacing.xs)
+                                .padding(.vertical, 6)
+                                .background(Color.white.opacity(0.1), in: Capsule())
                             }
                             .buttonStyle(.plain)
+                            .simultaneousGesture(
+                                LongPressGesture(minimumDuration: 0.45)
+                                    .onEnded { _ in
+                                        shouldIgnoreNextLikeTap = true
+                                        onLikeLongPress()
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                            shouldIgnoreNextLikeTap = false
+                                        }
+                                    }
+                            )
                         }
-                    }
 
-                    SocialFeedVideoSection(
-                        feed: feed,
-                        isVideoPlaying: isVideoPlaying,
-                        playbackFocusToken: playbackFocusToken,
-                        shouldLoadPlayer: shouldLoadPlayer,
-                        onPlaybackEnded: onVideoPlaybackEnded
-                    )
-
-                    VStack(alignment: .center, spacing: AppSpacing.xl) {
-                        Text("킬링파트 일기")
-                            .font(AppFont.paperlogy5Medium(size: 13))
-                            .foregroundStyle(Color.kpGray300)
-                            .frame(maxWidth: .infinity, alignment: .center)
-
-                        Text(feed.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "작성된 킬링파트 일기가 없어요." : feed.content)
-                            .font(AppFont.paperlogy4Regular(size: 13))
-                            .foregroundStyle(.white)
-                            .lineSpacing(2)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                            .multilineTextAlignment(.center)
+                        Button {
+                            onStoreTap()
+                        } label: {
+                            Image(systemName: feed.isStored ? "bookmark.fill" : "bookmark")
+                                .font(.system(size: 14, weight: .semibold))
+                                .foregroundStyle(AppColors.primary600)
+                                .padding(.horizontal, AppSpacing.xs)
+                                .padding(.vertical, 6)
+                                .background(Color.white.opacity(0.1), in: Capsule())
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
-                .padding(AppSpacing.m)
+
+                SocialFeedVideoSection(
+                    feed: feed,
+                    isVideoPlaying: isVideoPlaying,
+                    playbackFocusToken: playbackFocusToken,
+                    shouldLoadPlayer: shouldLoadPlayer,
+                    onPlaybackEnded: onVideoPlaybackEnded
+                )
             }
-            .scrollIndicators(.hidden)
+            .padding(.horizontal, AppSpacing.m)
+            .padding(.top, AppSpacing.m)
+
+            diarySection
+                .padding(.horizontal, AppSpacing.m)
+                .padding(.top, AppSpacing.m)
 
             VStack(alignment: .leading, spacing: AppSpacing.xs) {
                 Text("재생 구간")
@@ -153,6 +141,33 @@ struct SocialFeedPageCardView: View {
             .padding(.bottom, AppSpacing.l)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var diarySection: some View {
+        VStack(alignment: .center, spacing: AppSpacing.s) {
+            Text("킬링파트 일기")
+                .font(AppFont.paperlogy5Medium(size: 13))
+                .foregroundStyle(Color.kpGray300)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            ScrollView(.vertical) {
+                Text(diaryContentText)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(.white)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .multilineTextAlignment(.center)
+                    .padding(.bottom, AppSpacing.xs)
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private var diaryContentText: String {
+        let trimmed = feed.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "작성된 킬링파트 일기가 없어요." : feed.content
     }
 
     private var parsedEndSeconds: Double {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -8,8 +8,10 @@ struct SocialFeedPageCardView: View {
     let shouldLoadPlayer: Bool
     let onProfileTap: () -> Void
     let onLikeTap: () -> Void
+    let onLikeLongPress: () -> Void
     let onStoreTap: () -> Void
     let onVideoPlaybackEnded: () -> Void
+    @State private var shouldIgnoreNextLikeTap = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,6 +43,10 @@ struct SocialFeedPageCardView: View {
                         HStack(spacing: AppSpacing.s) {
                             HStack(spacing: 4) {
                                 Button {
+                                    if shouldIgnoreNextLikeTap {
+                                        shouldIgnoreNextLikeTap = false
+                                        return
+                                    }
                                     onLikeTap()
                                 } label: {
                                     HStack(spacing: 4) {
@@ -55,6 +61,16 @@ struct SocialFeedPageCardView: View {
                                     .background(Color.white.opacity(0.1), in: Capsule())
                                 }
                                 .buttonStyle(.plain)
+                                .simultaneousGesture(
+                                    LongPressGesture(minimumDuration: 0.45)
+                                        .onEnded { _ in
+                                            shouldIgnoreNextLikeTap = true
+                                            onLikeLongPress()
+                                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                                                shouldIgnoreNextLikeTap = false
+                                            }
+                                        }
+                                )
                             }
 
                             Button {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -33,7 +33,7 @@ struct SocialFeedPageCardView: View {
                                 Label {
                                     Text("신고하기")
                                 } icon: {
-                                    Image(systemName: "bell.fill")
+                                    Image(systemName: "light.beacon.max")
                                 }
                                 .tint(.red)
                             }

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SocialFeedPageCardView: View {
     let feed: DiaryFeedModel
     let isVideoPlaying: Bool
+    let playbackFocusToken: Int
     let elapsedInCurrentRange: TimeInterval
     let shouldLoadPlayer: Bool
     let onLikeTap: () -> Void
@@ -69,6 +70,7 @@ struct SocialFeedPageCardView: View {
                     SocialFeedVideoSection(
                         feed: feed,
                         isVideoPlaying: isVideoPlaying,
+                        playbackFocusToken: playbackFocusToken,
                         shouldLoadPlayer: shouldLoadPlayer,
                         onPlaybackEnded: onVideoPlaybackEnded
                     )
@@ -152,6 +154,7 @@ struct SocialFeedPageCardView: View {
 private struct SocialFeedVideoSection: View {
     let feed: DiaryFeedModel
     let isVideoPlaying: Bool
+    let playbackFocusToken: Int
     let shouldLoadPlayer: Bool
     let onPlaybackEnded: () -> Void
 
@@ -163,6 +166,7 @@ private struct SocialFeedVideoSection: View {
                     startSeconds: parsedSeconds(from: feed.start) ?? 0,
                     endSeconds: parsedEndSeconds,
                     isPlaying: isVideoPlaying,
+                    playbackFocusToken: playbackFocusToken,
                     shouldLoopPlayback: false,
                     onPlaybackEnded: onPlaybackEnded
                 )

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedPageCardView.swift
@@ -30,7 +30,12 @@ struct SocialFeedPageCardView: View {
                             Button {
                                 onReportTap()
                             } label: {
-                                Label("신고하기", systemImage: "exclamationmark.triangle.fill")
+                                Label {
+                                    Text("신고하기")
+                                } icon: {
+                                    Image(systemName: "bell.fill")
+                                }
+                                .tint(.red)
                             }
                         } label: {
                             Image(systemName: "ellipsis")

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedProfileView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/Components/SocialFeedProfileView.swift
@@ -6,6 +6,10 @@ struct SocialFeedProfileView: View {
     var body: some View {
         HStack(spacing: AppSpacing.xs) {
             SocialFriendProfileImageView(profileImageURL: profileImageURL)
+                .overlay {
+                    Circle()
+                        .stroke(Color.kpPrimary, lineWidth: 1.5)
+                }
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(feed.username?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? (feed.username ?? "") : "알 수 없음")

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -53,23 +53,20 @@ struct FeedSectionView: View {
         }
         .onAppear {
             isViewActive = true
-            elapsedInCurrentRange = 0
             previousFeedCount = viewModel.feeds.count
-            bumpPlaybackFocusToken()
+            handleFocusActivated()
         }
         .onDisappear {
             isViewActive = false
         }
         .onChange(of: scenePhase) { phase in
             if phase == .active {
-                elapsedInCurrentRange = 0
-                bumpPlaybackFocusToken()
+                handleFocusActivated()
             }
         }
         .onChange(of: isParentActive) { isParentActive in
             guard isParentActive else { return }
-            elapsedInCurrentRange = 0
-            bumpPlaybackFocusToken()
+            handleFocusActivated()
         }
         .onChange(of: viewModel.feeds.count) { newCount in
             let hasAppendedFeed = newCount > previousFeedCount
@@ -141,6 +138,7 @@ struct FeedSectionView: View {
         .onChange(of: isProfileNavigationActive) { isActive in
             if !isActive {
                 selectedProfileDestination = nil
+                handleFocusActivated()
             }
         }
         .background(profileNavigationLink)
@@ -171,6 +169,15 @@ struct FeedSectionView: View {
 
     private func bumpPlaybackFocusToken() {
         playbackFocusToken &+= 1
+    }
+
+    private func handleFocusActivated() {
+        guard isPlaybackActive else { return }
+        elapsedInCurrentRange = 0
+        bumpPlaybackFocusToken()
+        Task {
+            await viewModel.refreshLoadedFeedInteractionsIfNeeded()
+        }
     }
 
     private func makeSocialMyCollectionViewModel(for destination: ProfileDestination) -> SocialMyCollectionViewModel {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -17,6 +17,8 @@ struct FeedSectionView: View {
     @State private var pendingLikeUserDestination: UserModel?
     @State private var likeUsersSearchText = ""
     @State private var diaryReportContent = ""
+    @State private var activeInteractionFeedback: InteractionFeedback?
+    @State private var interactionFeedbackDismissTask: Task<Void, Never>?
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
@@ -56,6 +58,9 @@ struct FeedSectionView: View {
             }
             .padding(.bottom, bottomInset)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .overlay(alignment: .center) {
+                interactionFeedbackOverlay
+            }
         }
         .onAppear {
             isViewActive = true
@@ -64,6 +69,9 @@ struct FeedSectionView: View {
         }
         .onDisappear {
             isViewActive = false
+            interactionFeedbackDismissTask?.cancel()
+            interactionFeedbackDismissTask = nil
+            activeInteractionFeedback = nil
         }
         .onChange(of: scenePhase) { phase in
             if phase == .active {
@@ -182,6 +190,10 @@ struct FeedSectionView: View {
                             isProfileNavigationActive = true
                         },
                         onLikeTap: {
+                            presentInteractionFeedback(
+                                isLike: true,
+                                isEnabled: !feed.isLiked
+                            )
                             Task { await viewModel.toggleLike(diaryId: feed.diaryId) }
                         },
                         onLikeLongPress: {
@@ -192,6 +204,10 @@ struct FeedSectionView: View {
                             }
                         },
                         onStoreTap: {
+                            presentInteractionFeedback(
+                                isLike: false,
+                                isEnabled: !feed.isStored
+                            )
                             Task { await viewModel.toggleStore(diaryId: feed.diaryId) }
                         },
                         onReportTap: {
@@ -281,6 +297,39 @@ struct FeedSectionView: View {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    @ViewBuilder
+    private var interactionFeedbackOverlay: some View {
+        if let feedback = activeInteractionFeedback {
+            VStack(spacing: AppSpacing.s) {
+                Image(systemName: feedback.iconName)
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(feedback.iconColor)
+
+                Text(feedback.message)
+                    .font(AppFont.paperlogy5Medium(size: 13))
+                    .foregroundStyle(.white.opacity(0.95))
+            }
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.vertical, AppSpacing.m)
+            .background(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color.black.opacity(0.78))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(Color.white.opacity(0.18), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.32), radius: 14, y: 8)
+            .transition(
+                .asymmetric(
+                    insertion: .scale(scale: 0.84).combined(with: .opacity),
+                    removal: .offset(y: -18).combined(with: .opacity)
+                )
+            )
+            .allowsHitTesting(false)
+        }
+    }
+
     private func makeUserModel(from feed: DiaryFeedModel) -> UserModel {
         let username = trimmedString(feed.username, fallback: "킬링파트 사용자")
         let tag = normalizeTag(trimmedString(feed.tag, fallback: "killingpart_user"))
@@ -314,6 +363,38 @@ struct FeedSectionView: View {
         return rawTag
     }
 
+    private func presentInteractionFeedback(isLike: Bool, isEnabled: Bool) {
+        let feedback: InteractionFeedback
+        if isLike {
+            feedback = InteractionFeedback(
+                iconName: isEnabled ? "heart.fill" : "heart",
+                iconColor: isEnabled ? Color.kpPrimary : Color.white.opacity(0.8),
+                message: isEnabled ? "좋아요 했어요" : "좋아요를 취소했어요"
+            )
+        } else {
+            feedback = InteractionFeedback(
+                iconName: isEnabled ? "bookmark.fill" : "bookmark",
+                iconColor: isEnabled ? AppColors.primary600 : Color.white.opacity(0.8),
+                message: isEnabled ? "보관함에 저장했어요" : "보관함을 해제했어요"
+            )
+        }
+
+        interactionFeedbackDismissTask?.cancel()
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.76)) {
+            activeInteractionFeedback = feedback
+        }
+
+        interactionFeedbackDismissTask = Task {
+            try? await Task.sleep(nanoseconds: 900_000_000)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                withAnimation(.easeIn(duration: 0.22)) {
+                    activeInteractionFeedback = nil
+                }
+            }
+        }
+    }
+
     private struct LikeUsersSheetContext: Identifiable, Equatable {
         let diaryId: Int
         var id: Int { diaryId }
@@ -322,6 +403,12 @@ struct FeedSectionView: View {
     private struct DiaryReportSheetContext: Identifiable, Equatable {
         let diaryId: Int
         var id: Int { diaryId }
+    }
+
+    private struct InteractionFeedback {
+        let iconName: String
+        let iconColor: Color
+        let message: String
     }
      
     private func handleVideoPlaybackEnded(currentIndex: Int, feed: DiaryFeedModel) {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -4,13 +4,17 @@ struct FeedSectionView: View {
     @Environment(\.scenePhase) private var scenePhase
     @ObservedObject var viewModel: FeedViewModel
     let isParentActive: Bool
+    let makeCollectionViewModel: (UserModel) -> SocialMyCollectionViewModel
     @State private var currentPageIndex = 0
     @State private var elapsedInCurrentRange: TimeInterval = 0
     @State private var isViewActive = false
     @State private var previousFeedCount = 0
     @State private var playbackFocusToken = 0
-    @State private var selectedProfileDestination: ProfileDestination?
+    @State private var selectedProfileUser: UserModel?
     @State private var isProfileNavigationActive = false
+    @State private var activeLikeUsersSheet: LikeUsersSheetContext?
+    @State private var pendingLikeUserDestination: UserModel?
+    @State private var likeUsersSearchText = ""
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
@@ -75,6 +79,57 @@ struct FeedSectionView: View {
                 bumpPlaybackFocusToken()
             }
         }
+        .onChange(of: activeLikeUsersSheet) { sheetContext in
+            if sheetContext == nil {
+                viewModel.clearLikeUsersState()
+                likeUsersSearchText = ""
+                guard let pendingLikeUserDestination else { return }
+                self.pendingLikeUserDestination = nil
+                selectedProfileUser = pendingLikeUserDestination
+                DispatchQueue.main.async {
+                    isProfileNavigationActive = true
+                }
+            }
+        }
+        .sheet(item: $activeLikeUsersSheet) { sheetContext in
+            SocialDiaryLikeUsersSheet(
+                title: "좋아요한 사용자",
+                searchText: $likeUsersSearchText,
+                users: viewModel.likeUsers,
+                isLoading: viewModel.isLoadingLikeUsers,
+                isLoadingMore: viewModel.isLoadingMoreLikeUsers,
+                errorMessage: viewModel.likeUsersErrorMessage,
+                emptyMessage: "좋아요를 누른 사용자가 아직 없어요.",
+                onSearchSubmit: {
+                    Task {
+                        await viewModel.loadLikeUsers(
+                            diaryId: sheetContext.diaryId,
+                            searchCond: normalizedLikeUsersSearchCond
+                        )
+                    }
+                },
+                onSearchClear: {
+                    likeUsersSearchText = ""
+                    Task {
+                        await viewModel.loadLikeUsers(diaryId: sheetContext.diaryId, searchCond: nil)
+                    }
+                },
+                onRetry: {
+                    Task {
+                        await viewModel.retryLikeUsersLoading()
+                    }
+                },
+                onUserAppear: { userId in
+                    Task {
+                        await viewModel.loadMoreLikeUsersIfNeeded(currentUserId: userId)
+                    }
+                },
+                onUserTap: { user in
+                    pendingLikeUserDestination = user
+                    activeLikeUsersSheet = nil
+                }
+            )
+        }
     }
 
     private var feedPager: some View {
@@ -94,11 +149,18 @@ struct FeedSectionView: View {
                         shouldLoadPlayer: shouldLoadPlayer,
                         onProfileTap: {
                             guard feed.userId > 0 else { return }
-                            selectedProfileDestination = makeProfileDestination(from: feed)
+                            selectedProfileUser = makeUserModel(from: feed)
                             isProfileNavigationActive = true
                         },
                         onLikeTap: {
                             Task { await viewModel.toggleLike(diaryId: feed.diaryId) }
+                        },
+                        onLikeLongPress: {
+                            likeUsersSearchText = ""
+                            activeLikeUsersSheet = LikeUsersSheetContext(diaryId: feed.diaryId)
+                            Task {
+                                await viewModel.loadLikeUsers(diaryId: feed.diaryId, searchCond: nil)
+                            }
                         },
                         onStoreTap: {
                             Task { await viewModel.toggleStore(diaryId: feed.diaryId) }
@@ -137,7 +199,7 @@ struct FeedSectionView: View {
         }
         .onChange(of: isProfileNavigationActive) { isActive in
             if !isActive {
-                selectedProfileDestination = nil
+                selectedProfileUser = nil
                 handleFocusActivated()
             }
         }
@@ -152,9 +214,9 @@ struct FeedSectionView: View {
         NavigationLink(
             isActive: $isProfileNavigationActive,
             destination: {
-                if let selectedProfileDestination {
+                if let selectedProfileUser {
                     SocialMyCollectionView(
-                        viewModel: makeSocialMyCollectionViewModel(for: selectedProfileDestination)
+                        viewModel: makeCollectionViewModel(selectedProfileUser)
                     )
                 } else {
                     EmptyView()
@@ -180,44 +242,24 @@ struct FeedSectionView: View {
         }
     }
 
-    private func makeSocialMyCollectionViewModel(for destination: ProfileDestination) -> SocialMyCollectionViewModel {
-        let initialUser = makeUserModel(from: destination)
-
-        return SocialMyCollectionViewModel(
-            initialUser: initialUser,
-            onToggleMyPick: { userId, isCurrentlyMyPick in
-                let subscribeService = SubscribeService()
-                if isCurrentlyMyPick {
-                    try await subscribeService.unsubscribe(from: userId)
-                } else {
-                    try await subscribeService.subscribe(to: userId)
-                }
-            }
-        )
+    private var normalizedLikeUsersSearchCond: String? {
+        let trimmed = likeUsersSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func makeUserModel(from destination: ProfileDestination) -> UserModel {
-        let username = trimmedString(destination.username, fallback: "킬링파트 사용자")
-        let tag = normalizeTag(trimmedString(destination.tag, fallback: "killingpart_user"))
-        let profileImageUrl = trimmedString(destination.profileImageUrl, fallback: "")
+    private func makeUserModel(from feed: DiaryFeedModel) -> UserModel {
+        let username = trimmedString(feed.username, fallback: "킬링파트 사용자")
+        let tag = normalizeTag(trimmedString(feed.tag, fallback: "killingpart_user"))
+        let profileImageUrl = trimmedString(feed.profileImageUrl, fallback: "")
         return UserModel(
-            userId: destination.userId,
+            userId: feed.userId,
             username: username,
             tag: tag,
-            identifier: String(destination.userId),
+            identifier: String(feed.userId),
             profileImageUrl: profileImageUrl,
             userRoleType: "USER",
             socialType: "UNKNOWN",
             isMyPick: nil
-        )
-    }
-
-    private func makeProfileDestination(from feed: DiaryFeedModel) -> ProfileDestination {
-        ProfileDestination(
-            userId: feed.userId,
-            username: feed.username,
-            tag: feed.tag,
-            profileImageUrl: feed.profileImageUrl
         )
     }
 
@@ -238,13 +280,9 @@ struct FeedSectionView: View {
         return rawTag
     }
 
-    private struct ProfileDestination: Hashable, Identifiable {
-        let userId: Int
-        let username: String?
-        let tag: String?
-        let profileImageUrl: String?
-
-        var id: Int { userId }
+    private struct LikeUsersSheetContext: Identifiable, Equatable {
+        let diaryId: Int
+        var id: Int { diaryId }
     }
      
     private func handleVideoPlaybackEnded(currentIndex: Int, feed: DiaryFeedModel) {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -13,8 +13,10 @@ struct FeedSectionView: View {
     @State private var selectedProfileUser: UserModel?
     @State private var isProfileNavigationActive = false
     @State private var activeLikeUsersSheet: LikeUsersSheetContext?
+    @State private var activeDiaryReportSheet: DiaryReportSheetContext?
     @State private var pendingLikeUserDestination: UserModel?
     @State private var likeUsersSearchText = ""
+    @State private var diaryReportContent = ""
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
@@ -91,6 +93,12 @@ struct FeedSectionView: View {
                 }
             }
         }
+        .onChange(of: activeDiaryReportSheet) { sheetContext in
+            if sheetContext == nil {
+                diaryReportContent = ""
+                viewModel.clearDiaryReportState()
+            }
+        }
         .sheet(item: $activeLikeUsersSheet) { sheetContext in
             SocialDiaryLikeUsersSheet(
                 title: "좋아요한 사용자",
@@ -130,6 +138,27 @@ struct FeedSectionView: View {
                 }
             )
         }
+        .sheet(item: $activeDiaryReportSheet) { sheetContext in
+            SocialDiaryReportSheet(
+                reportReason: $diaryReportContent,
+                isSubmitting: viewModel.isReportingDiary,
+                errorMessage: viewModel.reportErrorMessage,
+                onCancel: {
+                    activeDiaryReportSheet = nil
+                },
+                onSubmit: {
+                    Task {
+                        let isSuccess = await viewModel.reportDiary(
+                            diaryId: sheetContext.diaryId,
+                            content: diaryReportContent
+                        )
+                        if isSuccess {
+                            activeDiaryReportSheet = nil
+                        }
+                    }
+                }
+            )
+        }
     }
 
     private var feedPager: some View {
@@ -164,6 +193,11 @@ struct FeedSectionView: View {
                         },
                         onStoreTap: {
                             Task { await viewModel.toggleStore(diaryId: feed.diaryId) }
+                        },
+                        onReportTap: {
+                            diaryReportContent = ""
+                            viewModel.clearDiaryReportState()
+                            activeDiaryReportSheet = DiaryReportSheetContext(diaryId: feed.diaryId)
                         },
                         onVideoPlaybackEnded: {
                             guard currentPageIndex == index else { return }
@@ -281,6 +315,11 @@ struct FeedSectionView: View {
     }
 
     private struct LikeUsersSheetContext: Identifiable, Equatable {
+        let diaryId: Int
+        var id: Int { diaryId }
+    }
+
+    private struct DiaryReportSheetContext: Identifiable, Equatable {
         let diaryId: Int
         var id: Int { diaryId }
     }

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -3,10 +3,12 @@ import SwiftUI
 struct FeedSectionView: View {
     @Environment(\.scenePhase) private var scenePhase
     @ObservedObject var viewModel: FeedViewModel
+    let isParentActive: Bool
     @State private var currentPageIndex = 0
     @State private var elapsedInCurrentRange: TimeInterval = 0
     @State private var isViewActive = false
     @State private var previousFeedCount = 0
+    @State private var playbackFocusToken = 0
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
@@ -51,6 +53,7 @@ struct FeedSectionView: View {
             isViewActive = true
             elapsedInCurrentRange = 0
             previousFeedCount = viewModel.feeds.count
+            bumpPlaybackFocusToken()
         }
         .onDisappear {
             isViewActive = false
@@ -58,10 +61,20 @@ struct FeedSectionView: View {
         .onChange(of: scenePhase) { phase in
             if phase == .active {
                 elapsedInCurrentRange = 0
+                bumpPlaybackFocusToken()
             }
         }
+        .onChange(of: isParentActive) { isParentActive in
+            guard isParentActive else { return }
+            elapsedInCurrentRange = 0
+            bumpPlaybackFocusToken()
+        }
         .onChange(of: viewModel.feeds.count) { newCount in
+            let hasAppendedFeed = newCount > previousFeedCount
             previousFeedCount = newCount
+            if hasAppendedFeed && isPlaybackActive {
+                bumpPlaybackFocusToken()
+            }
         }
     }
 
@@ -70,13 +83,14 @@ struct FeedSectionView: View {
             TabView(selection: $currentPageIndex) {
                 ForEach(viewModel.feeds.indices, id: \.self) { index in
                     let feed = viewModel.feeds[index]
-                    let isActive = index == currentPageIndex && isViewActive
-                    // 현재 페이지만 로드
-                    let shouldLoadPlayer = index == currentPageIndex
+                    let isActive = index == currentPageIndex && isPlaybackActive
+                    // 현재 페이지와 인접 페이지를 미리 로드해 스와이프 전환 시 버벅임을 줄인다.
+                    let shouldLoadPlayer = abs(index - currentPageIndex) <= 1
 
                     SocialFeedPageCardView(
                         feed: feed,
                         isVideoPlaying: isActive,
+                        playbackFocusToken: isActive ? playbackFocusToken : 0,
                         elapsedInCurrentRange: isActive ? elapsedInCurrentRange : 0,
                         shouldLoadPlayer: shouldLoadPlayer,
                         onLikeTap: {
@@ -110,12 +124,21 @@ struct FeedSectionView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onReceive(playbackTimer) { _ in
-            guard isViewActive else { return }
+            guard isPlaybackActive else { return }
             elapsedInCurrentRange += 0.25
         }
         .onChange(of: currentPageIndex) { _ in
             elapsedInCurrentRange = 0
+            bumpPlaybackFocusToken()
         }
+    }
+
+    private var isPlaybackActive: Bool {
+        isViewActive && isParentActive && scenePhase == .active
+    }
+
+    private func bumpPlaybackFocusToken() {
+        playbackFocusToken &+= 1
     }
     
     private func handleVideoPlaybackEnded(currentIndex: Int, feed: DiaryFeedModel) {

--- a/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FeedSection/FeedSectionView.swift
@@ -9,6 +9,8 @@ struct FeedSectionView: View {
     @State private var isViewActive = false
     @State private var previousFeedCount = 0
     @State private var playbackFocusToken = 0
+    @State private var selectedProfileDestination: ProfileDestination?
+    @State private var isProfileNavigationActive = false
 
     private let playbackTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
 
@@ -93,6 +95,11 @@ struct FeedSectionView: View {
                         playbackFocusToken: isActive ? playbackFocusToken : 0,
                         elapsedInCurrentRange: isActive ? elapsedInCurrentRange : 0,
                         shouldLoadPlayer: shouldLoadPlayer,
+                        onProfileTap: {
+                            guard feed.userId > 0 else { return }
+                            selectedProfileDestination = makeProfileDestination(from: feed)
+                            isProfileNavigationActive = true
+                        },
                         onLikeTap: {
                             Task { await viewModel.toggleLike(diaryId: feed.diaryId) }
                         },
@@ -131,16 +138,108 @@ struct FeedSectionView: View {
             elapsedInCurrentRange = 0
             bumpPlaybackFocusToken()
         }
+        .onChange(of: isProfileNavigationActive) { isActive in
+            if !isActive {
+                selectedProfileDestination = nil
+            }
+        }
+        .background(profileNavigationLink)
     }
 
     private var isPlaybackActive: Bool {
         isViewActive && isParentActive && scenePhase == .active
     }
 
+    private var profileNavigationLink: some View {
+        NavigationLink(
+            isActive: $isProfileNavigationActive,
+            destination: {
+                if let selectedProfileDestination {
+                    SocialMyCollectionView(
+                        viewModel: makeSocialMyCollectionViewModel(for: selectedProfileDestination)
+                    )
+                } else {
+                    EmptyView()
+                }
+            },
+            label: {
+                EmptyView()
+            }
+        )
+        .hidden()
+    }
+
     private func bumpPlaybackFocusToken() {
         playbackFocusToken &+= 1
     }
-    
+
+    private func makeSocialMyCollectionViewModel(for destination: ProfileDestination) -> SocialMyCollectionViewModel {
+        let initialUser = makeUserModel(from: destination)
+
+        return SocialMyCollectionViewModel(
+            initialUser: initialUser,
+            onToggleMyPick: { userId, isCurrentlyMyPick in
+                let subscribeService = SubscribeService()
+                if isCurrentlyMyPick {
+                    try await subscribeService.unsubscribe(from: userId)
+                } else {
+                    try await subscribeService.subscribe(to: userId)
+                }
+            }
+        )
+    }
+
+    private func makeUserModel(from destination: ProfileDestination) -> UserModel {
+        let username = trimmedString(destination.username, fallback: "킬링파트 사용자")
+        let tag = normalizeTag(trimmedString(destination.tag, fallback: "killingpart_user"))
+        let profileImageUrl = trimmedString(destination.profileImageUrl, fallback: "")
+        return UserModel(
+            userId: destination.userId,
+            username: username,
+            tag: tag,
+            identifier: String(destination.userId),
+            profileImageUrl: profileImageUrl,
+            userRoleType: "USER",
+            socialType: "UNKNOWN",
+            isMyPick: nil
+        )
+    }
+
+    private func makeProfileDestination(from feed: DiaryFeedModel) -> ProfileDestination {
+        ProfileDestination(
+            userId: feed.userId,
+            username: feed.username,
+            tag: feed.tag,
+            profileImageUrl: feed.profileImageUrl
+        )
+    }
+
+    private func trimmedString(_ raw: String?, fallback: String) -> String {
+        guard
+            let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else {
+            return fallback
+        }
+        return raw
+    }
+
+    private func normalizeTag(_ rawTag: String) -> String {
+        if rawTag.hasPrefix("@") {
+            return String(rawTag.dropFirst())
+        }
+        return rawTag
+    }
+
+    private struct ProfileDestination: Hashable, Identifiable {
+        let userId: Int
+        let username: String?
+        let tag: String?
+        let profileImageUrl: String?
+
+        var id: Int { userId }
+    }
+     
     private func handleVideoPlaybackEnded(currentIndex: Int, feed: DiaryFeedModel) {
         Task {
             let nextIndex = currentIndex + 1

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/Components/SocialFriendToggleTabsView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/Components/SocialFriendToggleTabsView.swift
@@ -18,32 +18,15 @@ struct SocialFriendToggleTabsView: View {
 
                         Text(totalCountText(for: section))
                             .font(AppFont.paperlogy4Regular(size: 12))
-                            .foregroundStyle(Color.white.opacity(0.8))
+                            .foregroundStyle(Color.kpPrimary.opacity(0.8))
                     }
                     .padding(.vertical, AppSpacing.xs)
-                    .frame(maxWidth: .infinity)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .fill(
-                                selectedFriendSection == section
-                                    ? AppColors.primary600.opacity(0.2)
-                                    : Color.white.opacity(0.06)
-                            )
-                    )
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(
-                                selectedFriendSection == section
-                                    ? AppColors.primary600.opacity(0.8)
-                                    : Color.white.opacity(0.2),
-                                lineWidth: 1
-                            )
-                    }
                 }
                 .buttonStyle(.plain)
                 .opacity(selectedFriendSection == section ? 1 : 0.45)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func totalCountText(for section: SocialFriendSection) -> String {

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/FriendsSectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/FriendsSectionView.swift
@@ -16,6 +16,7 @@ struct FriendsSectionView: View {
                     myPickCount: viewModel.totalCount(for: true),
                     myFandomCount: viewModel.totalCount(for: false)
                 )
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             SocialFriendListView(
                 users: currentSectionUsers,

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/SocialMyCollectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/SocialMyCollectionView.swift
@@ -31,7 +31,10 @@ struct SocialMyCollectionView: View {
                                 SocialMyCollectionDiary(
                                     diaryId: feed.diaryId,
                                     displayTag: viewModel.displayTag,
-                                    diary: diary
+                                    diary: diary,
+                                    makeCollectionViewModel: { user in
+                                        viewModel.makeSocialMyCollectionViewModel(for: user)
+                                    }
                                 )
                             } label: {
                                 SocialMyCollectionFeedCard(
@@ -166,7 +169,7 @@ struct SocialMyCollectionView: View {
             destination: {
                 if let selectedNavigationUser {
                     SocialMyCollectionView(
-                        viewModel: makeCollectionViewModel(for: selectedNavigationUser)
+                        viewModel: viewModel.makeSocialMyCollectionViewModel(for: selectedNavigationUser)
                     )
                     .id(selectedNavigationUser.userId)
                 } else {
@@ -185,20 +188,6 @@ struct SocialMyCollectionView: View {
         Task {
             await viewModel.loadConnections(type: sheetType.connectionType)
         }
-    }
-
-    private func makeCollectionViewModel(for user: SubscribeUserModel) -> SocialMyCollectionViewModel {
-        SocialMyCollectionViewModel(
-            initialUser: UserModel(from: user),
-            onToggleMyPick: { userId, isCurrentlyMyPick in
-                let subscribeService = SubscribeService()
-                if isCurrentlyMyPick {
-                    try await subscribeService.unsubscribe(from: userId)
-                } else {
-                    try await subscribeService.subscribe(to: userId)
-                }
-            }
-        )
     }
 
     private enum ConnectionSheetType: String, Identifiable {

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/SocialMyCollectionView.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/SocialMyCollectionView.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 struct SocialMyCollectionView: View {
     @StateObject private var viewModel: SocialMyCollectionViewModel
+    @State private var activeConnectionSheet: ConnectionSheetType?
+    @State private var pendingNavigationUser: SubscribeUserModel?
+    @State private var selectedNavigationUser: SubscribeUserModel?
+    @State private var isUserCollectionNavigationActive = false
 
     init(viewModel: SocialMyCollectionViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -70,6 +74,44 @@ struct SocialMyCollectionView: View {
         .task {
             await viewModel.loadInitialDataIfNeeded()
         }
+        .onChange(of: activeConnectionSheet) { sheetType in
+            guard sheetType == nil, let pendingNavigationUser else { return }
+            self.pendingNavigationUser = nil
+            selectedNavigationUser = pendingNavigationUser
+            DispatchQueue.main.async {
+                isUserCollectionNavigationActive = true
+            }
+        }
+        .onChange(of: isUserCollectionNavigationActive) { isActive in
+            if !isActive {
+                selectedNavigationUser = nil
+            }
+        }
+        .sheet(item: $activeConnectionSheet) { sheetType in
+            SocialMyCollectionConnectionListSheet(
+                title: sheetType.title,
+                users: viewModel.connectionUsers,
+                isLoading: viewModel.isLoadingConnections,
+                isLoadingMore: viewModel.isLoadingMoreConnections,
+                errorMessage: viewModel.connectionErrorMessage,
+                emptyMessage: sheetType.emptyMessage,
+                onRetry: {
+                    Task {
+                        await viewModel.refreshActiveConnections()
+                    }
+                },
+                onUserAppear: { userId in
+                    Task {
+                        await viewModel.loadMoreConnectionsIfNeeded(currentUserId: userId)
+                    }
+                },
+                onUserTap: { user in
+                    pendingNavigationUser = user
+                    activeConnectionSheet = nil
+                }
+            )
+        }
+        .background(userCollectionNavigationLink)
     }
 
     private var feedGridColumns: [GridItem] {
@@ -88,6 +130,12 @@ struct SocialMyCollectionView: View {
             fanStatText: viewModel.fanStatText,
             pickStatText: viewModel.pickStatText,
             isMyPick: viewModel.isMyPick,
+            onFanStatTap: {
+                presentConnectionSheet(.fandom)
+            },
+            onPickStatTap: {
+                presentConnectionSheet(.picks)
+            },
             onPickToggleTap: {
                 Task {
                     await viewModel.toggleMyPick()
@@ -110,5 +158,161 @@ struct SocialMyCollectionView: View {
                 RoundedRectangle(cornerRadius: 16)
                     .stroke(Color.white.opacity(0.12), lineWidth: 1)
             }
+    }
+
+    private var userCollectionNavigationLink: some View {
+        NavigationLink(
+            isActive: $isUserCollectionNavigationActive,
+            destination: {
+                if let selectedNavigationUser {
+                    SocialMyCollectionView(
+                        viewModel: makeCollectionViewModel(for: selectedNavigationUser)
+                    )
+                    .id(selectedNavigationUser.userId)
+                } else {
+                    EmptyView()
+                }
+            },
+            label: {
+                EmptyView()
+            }
+        )
+        .hidden()
+    }
+
+    private func presentConnectionSheet(_ sheetType: ConnectionSheetType) {
+        activeConnectionSheet = sheetType
+        Task {
+            await viewModel.loadConnections(type: sheetType.connectionType)
+        }
+    }
+
+    private func makeCollectionViewModel(for user: SubscribeUserModel) -> SocialMyCollectionViewModel {
+        SocialMyCollectionViewModel(
+            initialUser: UserModel(from: user),
+            onToggleMyPick: { userId, isCurrentlyMyPick in
+                let subscribeService = SubscribeService()
+                if isCurrentlyMyPick {
+                    try await subscribeService.unsubscribe(from: userId)
+                } else {
+                    try await subscribeService.subscribe(to: userId)
+                }
+            }
+        )
+    }
+
+    private enum ConnectionSheetType: String, Identifiable {
+        case picks
+        case fandom
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .picks:
+                return "PICKS"
+            case .fandom:
+                return "팬덤"
+            }
+        }
+
+        var emptyMessage: String {
+            switch self {
+            case .picks:
+                return "표시할 PICKS가 없어요."
+            case .fandom:
+                return "표시할 팬덤이 없어요."
+            }
+        }
+
+        var connectionType: SocialMyCollectionViewModel.ConnectionType {
+            switch self {
+            case .picks:
+                return .picks
+            case .fandom:
+                return .fandom
+            }
+        }
+    }
+}
+
+private struct SocialMyCollectionConnectionListSheet: View {
+    let title: String
+    let users: [SubscribeUserModel]
+    let isLoading: Bool
+    let isLoadingMore: Bool
+    let errorMessage: String?
+    let emptyMessage: String
+    let onRetry: () -> Void
+    let onUserAppear: (Int) -> Void
+    let onUserTap: (SubscribeUserModel) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.m) {
+            Text(title)
+                .font(AppFont.paperlogy6SemiBold(size: 16))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if isLoading && users.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .tint(AppColors.primary600)
+                    Spacer()
+                }
+                .padding(.top, AppSpacing.xl)
+            } else if let errorMessage, users.isEmpty {
+                VStack(spacing: AppSpacing.s) {
+                    Text(errorMessage)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(Color.white.opacity(0.8))
+                        .multilineTextAlignment(.center)
+
+                    Button("다시 시도") {
+                        onRetry()
+                    }
+                    .font(AppFont.paperlogy5Medium(size: 13))
+                    .foregroundStyle(AppColors.primary600)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, AppSpacing.xl)
+            } else if users.isEmpty {
+                Text(emptyMessage)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(Color.white.opacity(0.72))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, AppSpacing.xl)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: AppSpacing.s) {
+                        ForEach(users) { user in
+                            Button {
+                                onUserTap(user)
+                            } label: {
+                                SocialFriendRowView(user: .subscribed(user))
+                            }
+                            .buttonStyle(.plain)
+                            .onAppear {
+                                onUserAppear(user.userId)
+                            }
+                        }
+
+                        if isLoadingMore {
+                            ProgressView()
+                                .tint(AppColors.primary600)
+                                .padding(.top, AppSpacing.s)
+                        }
+                    }
+                    .padding(.bottom, AppSpacing.m)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.m)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .preferredColorScheme(.dark)
     }
 }

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
@@ -143,6 +143,12 @@ struct SocialMyCollectionDiary: View {
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                likeButton
+                storeButton
+            }
+        }
     }
 
     private var videoURL: URL? {
@@ -253,6 +259,50 @@ struct SocialMyCollectionDiary: View {
             guard isSuccess else { return }
             onDiaryUpdated?()
         }
+    }
+
+    private var likeButton: some View {
+        Button {
+            Task {
+                let isSuccess = await viewModel.toggleLike()
+                guard isSuccess else { return }
+                onDiaryUpdated?()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: viewModel.diary.isLiked ? "heart.fill" : "heart")
+                    .foregroundStyle(viewModel.diary.isLiked ? Color.kpPrimary : .white.opacity(0.75))
+                Text(viewModel.diary.likeCount.formatted())
+                    .font(AppFont.paperlogy4Regular(size: 12))
+                    .foregroundStyle(.white.opacity(0.85))
+            }
+            .padding(.horizontal, AppSpacing.xs)
+            .padding(.vertical, 6)
+            .background(Color.white.opacity(0.1), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted)
+        .opacity((viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted) ? 0.6 : 1)
+    }
+
+    private var storeButton: some View {
+        Button {
+            Task {
+                let isSuccess = await viewModel.toggleStore()
+                guard isSuccess else { return }
+                onDiaryUpdated?()
+            }
+        } label: {
+            Image(systemName: viewModel.diary.isStored ? "bookmark.fill" : "bookmark")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(AppColors.primary600)
+                .padding(.horizontal, AppSpacing.xs)
+                .padding(.vertical, 6)
+                .background(Color.white.opacity(0.1), in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted)
+        .opacity((viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted) ? 0.6 : 1)
     }
 
     private func dismissKeyboard() {

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
@@ -136,9 +136,12 @@ struct SocialMyCollectionDiary: View {
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { notification in
             updateKeyboardHeight(from: notification)
         }
+        .onAppear {
+            handleFocusActivated()
+        }
         .onChange(of: scenePhase) { phase in
             guard phase == .active else { return }
-            playerReloadToken = UUID()
+            handleFocusActivated()
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
@@ -303,6 +306,15 @@ struct SocialMyCollectionDiary: View {
         .buttonStyle(.plain)
         .disabled(viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted)
         .opacity((viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted) ? 0.6 : 1)
+    }
+
+    private func handleFocusActivated() {
+        playerReloadToken = UUID()
+        Task {
+            await viewModel.refreshInteractionStateIfNeeded(
+                preferredUserId: viewModel.diary.userId > 0 ? viewModel.diary.userId : nil
+            )
+        }
     }
 
     private func dismissKeyboard() {

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/[diaryId]/SocialMyCollectionDiary.swift
@@ -10,10 +10,17 @@ struct SocialMyCollectionDiary: View {
     let displayTag: String
     let onDiaryUpdated: (() -> Void)?
     let onDiaryDeleted: ((Int) -> Void)?
+    let makeCollectionViewModel: ((UserModel) -> SocialMyCollectionViewModel)?
     @StateObject private var viewModel: MyCollectionDiaryViewModel
     @State private var isDeleteDialogPresented = false
     @State private var keyboardHeight: CGFloat = 0
     @State private var playerReloadToken = UUID()
+    @State private var shouldIgnoreNextLikeTap = false
+    @State private var isLikeUsersSheetPresented = false
+    @State private var likeUsersSearchText = ""
+    @State private var pendingNavigationUser: UserModel?
+    @State private var selectedNavigationUser: UserModel?
+    @State private var isUserCollectionNavigationActive = false
 
     private let commentFocusAnchorID = "social-my-collection-diary-comment-focus-anchor"
 
@@ -23,12 +30,14 @@ struct SocialMyCollectionDiary: View {
         diary: DiaryFeedModel,
         onDiaryUpdated: (() -> Void)? = nil,
         onDiaryDeleted: ((Int) -> Void)? = nil,
+        makeCollectionViewModel: ((UserModel) -> SocialMyCollectionViewModel)? = nil,
         diaryService: DiaryServicing = DiaryService()
     ) {
         self.diaryId = diaryId
         self.displayTag = displayTag
         self.onDiaryUpdated = onDiaryUpdated
         self.onDiaryDeleted = onDiaryDeleted
+        self.makeCollectionViewModel = makeCollectionViewModel
         _viewModel = StateObject(
             wrappedValue: MyCollectionDiaryViewModel(
                 diary: diary,
@@ -143,6 +152,23 @@ struct SocialMyCollectionDiary: View {
             guard phase == .active else { return }
             handleFocusActivated()
         }
+        .onChange(of: isLikeUsersSheetPresented) { isPresented in
+            guard !isPresented else { return }
+            viewModel.clearLikeUsersState()
+            likeUsersSearchText = ""
+
+            guard let pendingNavigationUser else { return }
+            self.pendingNavigationUser = nil
+            selectedNavigationUser = pendingNavigationUser
+            DispatchQueue.main.async {
+                isUserCollectionNavigationActive = true
+            }
+        }
+        .onChange(of: isUserCollectionNavigationActive) { isActive in
+            if !isActive {
+                selectedNavigationUser = nil
+            }
+        }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.visible, for: .navigationBar)
@@ -152,6 +178,45 @@ struct SocialMyCollectionDiary: View {
                 storeButton
             }
         }
+        .sheet(isPresented: $isLikeUsersSheetPresented) {
+            SocialDiaryLikeUsersSheet(
+                title: "좋아요한 사용자",
+                searchText: $likeUsersSearchText,
+                users: viewModel.likeUsers,
+                isLoading: viewModel.isLoadingLikeUsers,
+                isLoadingMore: viewModel.isLoadingMoreLikeUsers,
+                errorMessage: viewModel.likeUsersErrorMessage,
+                emptyMessage: "좋아요를 누른 사용자가 아직 없어요.",
+                onSearchSubmit: {
+                    Task {
+                        await viewModel.loadLikeUsers(searchCond: normalizedLikeUsersSearchCond)
+                    }
+                },
+                onSearchClear: {
+                    likeUsersSearchText = ""
+                    Task {
+                        await viewModel.loadLikeUsers(searchCond: nil)
+                    }
+                },
+                onRetry: {
+                    Task {
+                        await viewModel.retryLikeUsersLoading()
+                    }
+                },
+                onUserAppear: { userId in
+                    Task {
+                        await viewModel.loadMoreLikeUsersIfNeeded(currentUserId: userId)
+                    }
+                },
+                onUserTap: { user in
+                    if makeCollectionViewModel != nil {
+                        pendingNavigationUser = user
+                    }
+                    isLikeUsersSheetPresented = false
+                }
+            )
+        }
+        .background(userCollectionNavigationLink)
     }
 
     private var videoURL: URL? {
@@ -266,6 +331,10 @@ struct SocialMyCollectionDiary: View {
 
     private var likeButton: some View {
         Button {
+            if shouldIgnoreNextLikeTap {
+                shouldIgnoreNextLikeTap = false
+                return
+            }
             Task {
                 let isSuccess = await viewModel.toggleLike()
                 guard isSuccess else { return }
@@ -284,8 +353,23 @@ struct SocialMyCollectionDiary: View {
             .background(Color.white.opacity(0.1), in: Capsule())
         }
         .buttonStyle(.plain)
-        .disabled(viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted)
-        .opacity((viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted) ? 0.6 : 1)
+        .disabled(isLikeInteractionDisabled)
+        .opacity(isLikeInteractionDisabled ? 0.6 : 1)
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.45)
+                .onEnded { _ in
+                    guard !isLikeInteractionDisabled else { return }
+                    shouldIgnoreNextLikeTap = true
+                    isLikeUsersSheetPresented = true
+                    likeUsersSearchText = ""
+                    Task {
+                        await viewModel.loadLikeUsers(searchCond: nil)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        shouldIgnoreNextLikeTap = false
+                    }
+                }
+        )
     }
 
     private var storeButton: some View {
@@ -304,8 +388,8 @@ struct SocialMyCollectionDiary: View {
                 .background(Color.white.opacity(0.1), in: Capsule())
         }
         .buttonStyle(.plain)
-        .disabled(viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted)
-        .opacity((viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted) ? 0.6 : 1)
+        .disabled(isLikeInteractionDisabled)
+        .opacity(isLikeInteractionDisabled ? 0.6 : 1)
     }
 
     private func handleFocusActivated() {
@@ -315,6 +399,36 @@ struct SocialMyCollectionDiary: View {
                 preferredUserId: viewModel.diary.userId > 0 ? viewModel.diary.userId : nil
             )
         }
+    }
+
+    private var userCollectionNavigationLink: some View {
+        NavigationLink(
+            isActive: $isUserCollectionNavigationActive,
+            destination: {
+                if let selectedNavigationUser,
+                   let makeCollectionViewModel {
+                    SocialMyCollectionView(
+                        viewModel: makeCollectionViewModel(selectedNavigationUser)
+                    )
+                    .id(selectedNavigationUser.userId)
+                } else {
+                    EmptyView()
+                }
+            },
+            label: {
+                EmptyView()
+            }
+        )
+        .hidden()
+    }
+
+    private var normalizedLikeUsersSearchCond: String? {
+        let trimmed = likeUsersSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var isLikeInteractionDisabled: Bool {
+        viewModel.isUpdatingInteraction || viewModel.isProcessing || viewModel.isDeleted
     }
 
     private func dismissKeyboard() {

--- a/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/components/SocialMyCollectionProfileCard.swift
+++ b/KillingPart/Views/Screens/Main/Social/FriendsSection/SocialMyCollection/[userId]/components/SocialMyCollectionProfileCard.swift
@@ -8,6 +8,8 @@ struct SocialMyCollectionProfileCard: View {
     let fanStatText: String
     let pickStatText: String
     let isMyPick: Bool
+    let onFanStatTap: () -> Void
+    let onPickStatTap: () -> Void
     let onPickToggleTap: () -> Void
 
     var body: some View {
@@ -36,8 +38,15 @@ struct SocialMyCollectionProfileCard: View {
 
                         HStack(alignment: .center, spacing: AppSpacing.m) {
                             MyCollectionProfileStatItemView(value: killingPartStatText, title: "킬링파트")
-                            MyCollectionProfileStatItemView(value: fanStatText, title: "팬덤")
-                            MyCollectionProfileStatItemView(value: pickStatText, title: "PICKS")
+                            Button(action: onFanStatTap) {
+                                MyCollectionProfileStatItemView(value: fanStatText, title: "팬덤")
+                            }
+                            .buttonStyle(.plain)
+
+                            Button(action: onPickStatTap) {
+                                MyCollectionProfileStatItemView(value: pickStatText, title: "PICKS")
+                            }
+                            .buttonStyle(.plain)
                         }
                         .frame(maxWidth: .infinity, alignment: .center)
                     }

--- a/KillingPart/Views/Screens/Main/Social/Shared/Components/SocialDiaryLikeUsersSheet.swift
+++ b/KillingPart/Views/Screens/Main/Social/Shared/Components/SocialDiaryLikeUsersSheet.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct SocialDiaryLikeUsersSheet: View {
+    let title: String
+    @Binding var searchText: String
+    let users: [UserModel]
+    let isLoading: Bool
+    let isLoadingMore: Bool
+    let errorMessage: String?
+    let emptyMessage: String
+    let onSearchSubmit: () -> Void
+    let onSearchClear: () -> Void
+    let onRetry: () -> Void
+    let onUserAppear: (Int) -> Void
+    let onUserTap: (UserModel) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.m) {
+            Text(title)
+                .font(AppFont.paperlogy6SemiBold(size: 16))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            searchBar
+
+            if isLoading && users.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                        .tint(AppColors.primary600)
+                    Spacer()
+                }
+                .padding(.top, AppSpacing.xl)
+            } else if let errorMessage, users.isEmpty {
+                VStack(spacing: AppSpacing.s) {
+                    Text(errorMessage)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(Color.white.opacity(0.8))
+                        .multilineTextAlignment(.center)
+
+                    Button("다시 시도") {
+                        onRetry()
+                    }
+                    .font(AppFont.paperlogy5Medium(size: 13))
+                    .foregroundStyle(AppColors.primary600)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, AppSpacing.xl)
+            } else if users.isEmpty {
+                Text(emptyMessage)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(Color.white.opacity(0.72))
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, AppSpacing.xl)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: AppSpacing.s) {
+                        ForEach(users) { user in
+                            Button {
+                                onUserTap(user)
+                            } label: {
+                                SocialFriendRowView(user: .searched(user))
+                            }
+                            .buttonStyle(.plain)
+                            .onAppear {
+                                onUserAppear(user.userId)
+                            }
+                        }
+
+                        if isLoadingMore {
+                            ProgressView()
+                                .tint(AppColors.primary600)
+                                .padding(.top, AppSpacing.s)
+                        }
+                    }
+                    .padding(.bottom, AppSpacing.m)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.m)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+        .preferredColorScheme(.dark)
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: AppSpacing.s) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Color.white.opacity(0.75))
+
+            TextField("태그 또는 유저 검색", text: $searchText)
+                .font(AppFont.paperlogy4Regular(size: 14))
+                .foregroundStyle(.white)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.search)
+                .onSubmit {
+                    onSearchSubmit()
+                }
+
+            Button {
+                onSearchSubmit()
+            } label: {
+                Text("검색")
+                    .font(AppFont.paperlogy5Medium(size: 12))
+                    .foregroundStyle(AppColors.primary600)
+            }
+            .buttonStyle(.plain)
+
+            if !searchText.isEmpty {
+                Button {
+                    onSearchClear()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Color.white.opacity(0.7))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, AppSpacing.m)
+        .frame(height: 52)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+        }
+    }
+}

--- a/KillingPart/Views/Screens/Main/Social/SocialView.swift
+++ b/KillingPart/Views/Screens/Main/Social/SocialView.swift
@@ -27,7 +27,10 @@ struct SocialView: View {
                         } else {
                             FeedSectionView(
                                 viewModel: feedViewModel,
-                                isParentActive: isRootTabSelected && selectedTopTab == .feed
+                                isParentActive: isRootTabSelected && selectedTopTab == .feed,
+                                makeCollectionViewModel: { user in
+                                    viewModel.makeSocialMyCollectionViewModel(for: user)
+                                }
                             )
                         }
                     }

--- a/KillingPart/Views/Screens/Main/Social/SocialView.swift
+++ b/KillingPart/Views/Screens/Main/Social/SocialView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SocialView: View {
+    let isRootTabSelected: Bool
     @StateObject private var viewModel = SocialViewModel()
     @StateObject private var feedViewModel = FeedViewModel()
     @State private var selectedTopTab: SocialTopTab = .friend
@@ -24,7 +25,10 @@ struct SocialView: View {
                         if selectedTopTab == .friend {
                             FriendsSectionView(viewModel: viewModel)
                         } else {
-                            FeedSectionView(viewModel: feedViewModel)
+                            FeedSectionView(
+                                viewModel: feedViewModel,
+                                isParentActive: isRootTabSelected && selectedTopTab == .feed
+                            )
                         }
                     }
                     .padding(.horizontal, AppSpacing.m)
@@ -48,5 +52,5 @@ struct SocialView: View {
 }
 
 #Preview {
-    SocialView()
+    SocialView(isRootTabSelected: true)
 }


### PR DESCRIPTION
## 작업 내용

- [x] 저전력모드 유튜브 재생 멈춤 이슈 해결
- [x] 피드/다른유저 컬렉션 진입
- [x] 좋아요버튼 꾹 누를 시 좋아요 목록 바텀시트
- [x] 신고하기 버튼 추가
- [x] 다른유저 다이어리 좋아요,스크랩 버튼 추가
- [x] 다른유저 PICKS, 팬덤 이벤트 시 팬덤,PICKS 목록 바텀시트 추가
- [x] 내 컬렉션 팬덤, PICKS, 좋아요목록 바텀시트 추가
- [x] 검색/좋아요/팬덤/PICKS 유저목록 중 나의 픽인 유저들은 프로필 카드 우측에 나의 픽 표시
- [x] 하트 이벤트 피드백 UI 추가
- [x] 킬링파트 일기 부분만 스크롤 적용
- [x] 프로필 배경 kpPrimary 추가

## 다음 업데이트
- [ ] 보관함 킬링파트 기능