### PR TITLE
feat - 온보딩 리뉴얼

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(awk '/private struct TutorialDiaryDetailScreen/,/private struct TutorialNotificationScreen/' /Users/ibyeongchan/Desktop/KillingPart/KillingPoint-iOS/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift)"
+    ]
+  }
+}

--- a/KillingPart/Info.plist
+++ b/KillingPart/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>MUSIC_BASE_URL</key>
 	<string>$(MUSIC_BASE_URL)</string>
+	<key>APP_STORE_URL</key>
+	<string>$(APP_STORE_URL)</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>kakaokompassauth</string>

--- a/KillingPart/Models/AppFlowStep.swift
+++ b/KillingPart/Models/AppFlowStep.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum AppFlowStep {
     case splash
-    case onboarding
     case login
+    case setup
     case main
 }

--- a/KillingPart/Models/UserModel.swift
+++ b/KillingPart/Models/UserModel.swift
@@ -153,6 +153,55 @@ struct UpdateMyTagRequest: Encodable {
     let tag: String
 }
 
+struct UpdateMyUsernameRequest: Encodable {
+    let username: String
+}
+
+struct UserInitSettingsResponse: Decodable {
+    let app: UserAppUpdateStatus
+    let needsPolicyAgreement: Bool
+    let needsTagSetup: Bool
+    let policies: [UserPolicyStatus]
+}
+
+struct UserAppUpdateStatus: Decodable {
+    let needsForceUpdate: Bool
+    let needsOptionalUpdate: Bool
+}
+
+struct UserPolicyStatus: Decodable, Identifiable {
+    let policyType: UserPolicyType
+    let required: Bool
+    let agreed: Bool
+    let currentRevision: Int
+    let latestRevision: Int
+
+    var id: UserPolicyType { policyType }
+}
+
+enum UserPolicyType: String, Codable, CaseIterable {
+    case serviceTerms = "SERVICE_TERMS"
+    case privacy = "PRIVACY"
+
+    var displayTitle: String {
+        switch self {
+        case .serviceTerms:
+            return "서비스 이용약관"
+        case .privacy:
+            return "개인정보 처리방침"
+        }
+    }
+}
+
+struct PolicyAgreementRequest: Encodable {
+    let agreements: [PolicyAgreementItem]
+}
+
+struct PolicyAgreementItem: Encodable {
+    let policyType: UserPolicyType
+    let agreed: Bool
+}
+
 private extension KeyedDecodingContainer {
     func decodeFlexibleBoolIfPresent(forKey key: K) -> Bool? {
         if let boolValue = try? decodeIfPresent(Bool.self, forKey: key) {

--- a/KillingPart/Services/UserService.swift
+++ b/KillingPart/Services/UserService.swift
@@ -2,12 +2,15 @@ import Foundation
 
 protocol UserServicing {
     func fetchMyUser() async throws -> UserModel
+    func fetchInitSettings() async throws -> UserInitSettingsResponse
+    func submitPolicyAgreement(agreements: [PolicyAgreementItem]) async throws
     func fetchUserStatics(userId: Int) async throws -> UserStaticsModel
     func searchUsers(searchCond: String?, page: Int, size: Int) async throws -> UserSearchResponse
     func deleteMyProfileImage() async throws -> UserModel
     func issuePresignedURL() async throws -> PresignedURLResponse
     func uploadImageToPresignedURL(imageData: Data, presignedURL: URL) async throws
     func updateMyProfileImage(request: UpdateMyProfileImageRequest) async throws -> UserModel
+    func updateMyUsername(username: String) async throws -> UserModel
     func updateMyTag(tag: String) async throws -> UserModel
 }
 
@@ -66,6 +69,47 @@ struct UserService: UserServicing {
             let response = try await apiClient.request(request, responseType: UserResponseDTO.self)
             return response.toModel()
         } catch {
+            throw mapError(error)
+        }
+    }
+
+    func fetchInitSettings() async throws -> UserInitSettingsResponse {
+        do {
+            let request = APIRequest(
+                path: "/users/init-settings",
+                method: .get,
+                queryItems: [
+                    URLQueryItem(name: "clientVersion", value: Self.clientVersion),
+                    URLQueryItem(name: "clientType", value: Self.clientType)
+                ],
+                requiresAuthorization: true
+            )
+            return try await apiClient.request(request, responseType: UserInitSettingsResponse.self)
+        } catch {
+            throw mapError(error)
+        }
+    }
+
+    func submitPolicyAgreement(agreements: [PolicyAgreementItem]) async throws {
+        let requestBody: Data
+        do {
+            requestBody = try JSONEncoder().encode(PolicyAgreementRequest(agreements: agreements))
+        } catch {
+            throw UserServiceError.requestEncodingFailed
+        }
+
+        do {
+            var request = APIRequest(
+                path: "/users/policy-agreement",
+                method: .post,
+                requiresAuthorization: true,
+                body: requestBody
+            )
+            request.headers["Accept"] = "application/json"
+            request.headers["Content-Type"] = "application/json"
+            try await apiClient.request(request)
+        } catch {
+            if isRequestCancelled(error) { throw error }
             throw mapError(error)
         }
     }
@@ -221,6 +265,31 @@ struct UserService: UserServicing {
         }
     }
 
+    func updateMyUsername(username: String) async throws -> UserModel {
+        let requestBody: Data
+        do {
+            requestBody = try JSONEncoder().encode(UpdateMyUsernameRequest(username: username))
+        } catch {
+            throw UserServiceError.requestEncodingFailed
+        }
+
+        do {
+            var request = APIRequest(
+                path: "/users/my/names",
+                method: .patch,
+                requiresAuthorization: true,
+                body: requestBody
+            )
+            request.headers["Accept"] = "application/json"
+            request.headers["Content-Type"] = "application/json"
+            let response = try await apiClient.request(request, responseType: UserResponseDTO.self)
+            return response.toModel()
+        } catch {
+            if isRequestCancelled(error) { throw error }
+            throw mapError(error)
+        }
+    }
+
     private func mapError(_ error: Error) -> UserServiceError {
         if let userServiceError = error as? UserServiceError {
             return userServiceError
@@ -299,6 +368,17 @@ struct UserService: UserServicing {
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
     }
+
+    private static var clientVersion: String {
+        let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        let resolved = (shortVersion?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? shortVersion
+            : buildVersion) ?? "0.0.0"
+        return resolved
+    }
+
+    private static let clientType = "IOS"
 }
 
 private struct UserServiceErrorResponse: Decodable {

--- a/KillingPart/ViewModels/AppViewModel.swift
+++ b/KillingPart/ViewModels/AppViewModel.swift
@@ -2,22 +2,68 @@ import Foundation
 
 @MainActor
 final class AppViewModel: ObservableObject {
+    enum UpdatePrompt: Identifiable, Equatable {
+        case force
+        case optional
+
+        var id: String {
+            switch self {
+            case .force:
+                return "force"
+            case .optional:
+                return "optional"
+            }
+        }
+
+        var title: String {
+            switch self {
+            case .force:
+                return "업데이트 필요"
+            case .optional:
+                return "업데이트 권장"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .force:
+                return "안정적인 서비스 이용을 위해 최신 버전으로 업데이트해 주세요."
+            case .optional:
+                return "새 버전이 출시되었어요. 지금 업데이트하면 더 나은 경험을 이용할 수 있어요."
+            }
+        }
+    }
+
     @Published var currentStep: AppFlowStep = .splash
+    @Published var updatePrompt: UpdatePrompt?
+    @Published var setupFlowViewModel: InitialSetupFlowViewModel?
+    @Published var isResolvingPostLoginFlow = false
 
     let loginViewModel: LoginViewModel
 
     private let tokenStore: TokenStoring
+    private let userService: UserServicing
+    private let diaryService: DiaryServicing
+    private let calendarService: CalendarServicing
     private let notificationCenter: NotificationCenter
+    private let appStoreURL: URL?
     private var sessionExpiredObserver: NSObjectProtocol?
 
     init(
         authenticationService: AuthenticationServicing = AuthenticationService(),
         authService: AuthServicing = AuthService(),
+        userService: UserServicing = UserService(),
+        diaryService: DiaryServicing = DiaryService(),
+        calendarService: CalendarServicing = CalendarService(),
         tokenStore: TokenStoring = TokenStore.shared,
         notificationCenter: NotificationCenter = .default
     ) {
         self.tokenStore = tokenStore
+        self.userService = userService
+        self.diaryService = diaryService
+        self.calendarService = calendarService
         self.notificationCenter = notificationCenter
+        self.appStoreURL = Self.resolveAppStoreURL()
 
         let loginViewModel = LoginViewModel(
             authenticationService: authenticationService,
@@ -26,7 +72,9 @@ final class AppViewModel: ObservableObject {
 
         self.loginViewModel = loginViewModel
         self.loginViewModel.onLoginSuccess = { [weak self] _ in
-            self?.currentStep = .main
+            Task { @MainActor [weak self] in
+                await self?.resolvePostLoginFlow()
+            }
         }
 
         sessionExpiredObserver = notificationCenter.addObserver(
@@ -47,15 +95,115 @@ final class AppViewModel: ObservableObject {
     }
 
     func completeSplash() {
-        currentStep = tokenStore.hasSessionTokens ? .main : .onboarding
+        guard tokenStore.hasSessionTokens else {
+            currentStep = .login
+            return
+        }
+
+        Task {
+            await resolvePostLoginFlow()
+        }
     }
 
-    func completeOnboarding() {
-        currentStep = tokenStore.hasSessionTokens ? .main : .login
+    func resolvePostLoginFlow() async {
+        guard !isResolvingPostLoginFlow else { return }
+
+        isResolvingPostLoginFlow = true
+        loginViewModel.loginErrorMessage = nil
+        defer { isResolvingPostLoginFlow = false }
+
+        do {
+            let settings = try await userService.fetchInitSettings()
+            applyRoute(for: settings)
+
+            if settings.app.needsForceUpdate {
+                updatePrompt = .force
+            } else if settings.app.needsOptionalUpdate {
+                updatePrompt = .optional
+            }
+        } catch {
+            if isRequestCancelled(error) { return }
+            currentStep = .login
+            setupFlowViewModel = nil
+            loginViewModel.loginErrorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func openAppStoreURLForUpdate() -> URL? {
+        appStoreURL
+    }
+
+    func dismissOptionalUpdatePrompt() {
+        guard updatePrompt == .optional else { return }
+        updatePrompt = nil
     }
 
     func logout() {
         loginViewModel.resetState()
+        setupFlowViewModel = nil
+        updatePrompt = nil
         currentStep = .login
+    }
+
+    private func applyRoute(for settings: UserInitSettingsResponse) {
+        if settings.needsPolicyAgreement || settings.needsTagSetup {
+            let setupViewModel = InitialSetupFlowViewModel(
+                settings: settings,
+                userService: userService,
+                diaryService: diaryService,
+                calendarService: calendarService
+            )
+            setupViewModel.onComplete = { [weak self] in
+                self?.enterMainFlow()
+            }
+            setupFlowViewModel = setupViewModel
+            currentStep = .setup
+            return
+        }
+
+        enterMainFlow()
+    }
+
+    private func enterMainFlow() {
+        setupFlowViewModel = nil
+        currentStep = .main
+    }
+
+    private func resolveErrorMessage(from error: Error) -> String {
+        if let userServiceError = error as? UserServiceError {
+            return userServiceError.errorDescription ?? "초기 설정 정보를 불러오지 못했어요."
+        }
+
+        if let apiError = error as? APIClientError {
+            return apiError.errorDescription ?? "초기 설정 정보를 불러오지 못했어요."
+        }
+
+        if let localizedError = error as? LocalizedError {
+            return localizedError.errorDescription ?? "초기 설정 정보를 불러오지 못했어요."
+        }
+
+        return "초기 설정 정보를 불러오지 못했어요."
+    }
+
+    private func isRequestCancelled(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    private static func resolveAppStoreURL() -> URL? {
+        guard
+            let rawValue = Bundle.main.object(forInfoDictionaryKey: "APP_STORE_URL") as? String
+        else {
+            return nil
+        }
+
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = URL(string: trimmed) else {
+            return nil
+        }
+
+        return url
     }
 }

--- a/KillingPart/ViewModels/InitialSetupFlowViewModel.swift
+++ b/KillingPart/ViewModels/InitialSetupFlowViewModel.swift
@@ -1,0 +1,363 @@
+import Foundation
+
+@MainActor
+final class InitialSetupFlowViewModel: ObservableObject {
+    enum Step: Hashable {
+        case policyAgreement
+        case nameSetup
+        case tagSetup
+        case tutorialChoice
+        case tutorialTrackSearch
+        case tutorialTrim
+        case tutorialHome
+        case tutorialDiaryDetail
+        case tutorialNotification
+        case tutorialFinal
+    }
+
+    @Published private(set) var step: Step
+    @Published private(set) var initSettings: UserInitSettingsResponse
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+
+    @Published var isServiceTermsAgreed: Bool = false
+    @Published var isPrivacyAgreed: Bool = false
+
+    @Published var nameDraft = ""
+    @Published var tagDraft = ""
+
+    @Published var selectedTrack: SpotifySimpleTrack?
+    @Published private(set) var tutorialDiaries: [DiaryFeedModel] = []
+    @Published private(set) var calendarDiaryCountByDate: [(String, Int)] = []
+    @Published private(set) var calendarDiariesByDate: [String: [DiaryFeedModel]] = [:]
+    @Published private(set) var displayName: String = "홍길동"
+    @Published private(set) var displayTag: String = "@killingpart_user"
+
+    private let userService: UserServicing
+    private let diaryService: DiaryServicing
+    private let calendarService: CalendarServicing
+
+    var onComplete: (() -> Void)?
+
+    init(
+        settings: UserInitSettingsResponse,
+        userService: UserServicing = UserService(),
+        diaryService: DiaryServicing = DiaryService(),
+        calendarService: CalendarServicing = CalendarService()
+    ) {
+        self.initSettings = settings
+        self.userService = userService
+        self.diaryService = diaryService
+        self.calendarService = calendarService
+        self.step = settings.needsPolicyAgreement
+            ? .policyAgreement
+            : (settings.needsTagSetup ? .nameSetup : .tutorialChoice)
+        syncPolicyAgreementState(with: settings)
+    }
+
+    var canSubmitPolicyAgreement: Bool {
+        isServiceTermsAgreed && isPrivacyAgreed
+    }
+
+    var canSubmitName: Bool {
+        validateName(nameDraft) == nil
+    }
+
+    var canSubmitTag: Bool {
+        validateTag(tagDraft) == nil
+    }
+
+    func openTutorialChoice() {
+        step = .tutorialChoice
+    }
+
+    func submitPolicyAgreement() async {
+        guard !isLoading else { return }
+        guard canSubmitPolicyAgreement else {
+            errorMessage = "필수 약관에 모두 동의해 주세요."
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let agreements = initSettings.policies.map { policy in
+                PolicyAgreementItem(
+                    policyType: policy.policyType,
+                    agreed: agreementValue(for: policy.policyType)
+                )
+            }
+            try await userService.submitPolicyAgreement(agreements: agreements)
+            let refreshedSettings = try await userService.fetchInitSettings()
+            applyRefreshedSettingsAfterPolicyAgreement(refreshedSettings)
+        } catch {
+            if isRequestCancelled(error) { return }
+            errorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func submitName() async {
+        guard !isLoading else { return }
+        guard let validationError = validateName(nameDraft) else {
+            isLoading = true
+            errorMessage = nil
+            defer { isLoading = false }
+
+            do {
+                _ = try await userService.updateMyUsername(username: normalizedName(nameDraft))
+                step = .tagSetup
+            } catch {
+                if isRequestCancelled(error) { return }
+                errorMessage = resolveErrorMessage(from: error)
+            }
+            return
+        }
+
+        errorMessage = validationError
+    }
+
+    func submitTag() async {
+        guard !isLoading else { return }
+        guard let validationError = validateTag(tagDraft) else {
+            isLoading = true
+            errorMessage = nil
+            defer { isLoading = false }
+
+            do {
+                let updatedUser = try await userService.updateMyTag(tag: normalizedTag(tagDraft))
+                let trimmedTag = updatedUser.tag.trimmingCharacters(in: .whitespacesAndNewlines)
+                displayTag = trimmedTag.hasPrefix("@") ? trimmedTag : "@\(trimmedTag)"
+                step = .tutorialChoice
+            } catch {
+                if isRequestCancelled(error) { return }
+                errorMessage = resolveErrorMessage(from: error)
+            }
+            return
+        }
+
+        errorMessage = validationError
+    }
+
+    func startTutorialTrackSelection() {
+        errorMessage = nil
+        step = .tutorialTrackSearch
+    }
+
+    func skipAllTutorialAndFinish() {
+        onComplete?()
+    }
+
+    func selectTutorialTrack(_ track: SpotifySimpleTrack) {
+        selectedTrack = track
+        errorMessage = nil
+        step = .tutorialTrim
+    }
+
+    func moveToTutorialHomeAfterDiarySaved() async {
+        await loadTutorialHomeData()
+        guard !tutorialDiaries.isEmpty else {
+            errorMessage = "튜토리얼 데이터를 불러오지 못했어요. 다시 시도해 주세요."
+            return
+        }
+        step = .tutorialHome
+    }
+
+    func loadTutorialHomeData() async {
+        guard !isLoading else { return }
+
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let user = try await userService.fetchMyUser()
+            let trimmedName = user.username.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedTag = user.tag.trimmingCharacters(in: .whitespacesAndNewlines)
+            displayName = trimmedName.isEmpty ? "홍길동" : trimmedName
+            displayTag = trimmedTag.isEmpty ? "@killingpart_user" : (trimmedTag.hasPrefix("@") ? trimmedTag : "@\(trimmedTag)")
+        } catch {
+            if !isRequestCancelled(error) {
+                displayName = "홍길동"
+                displayTag = "@killingpart_user"
+            }
+        }
+
+        do {
+            async let diariesTask = diaryService.fetchMyDiaries(page: 0, size: 20)
+            async let calendarTask = calendarService.fetchMyCalendarDiaries(
+                startDate: Self.currentMonthStartDate,
+                endDate: Self.currentMonthEndDate
+            )
+
+            let (diaryResponse, calendarResponse) = try await (diariesTask, calendarTask)
+            tutorialDiaries = diaryResponse.content
+            calendarDiariesByDate = calendarResponse.diariesByDate
+
+            let sorted = calendarResponse.diariesByDate
+                .map { ($0.key, $0.value.count) }
+                .sorted { $0.0 < $1.0 }
+            calendarDiaryCountByDate = sorted
+        } catch {
+            if isRequestCancelled(error) { return }
+            errorMessage = resolveErrorMessage(from: error)
+        }
+    }
+
+    func goToDiaryDetailTutorial() {
+        guard !tutorialDiaries.isEmpty else {
+            errorMessage = "다이어리 데이터가 없어요."
+            return
+        }
+        step = .tutorialDiaryDetail
+    }
+
+    func goToNotificationTutorial() {
+        step = .tutorialNotification
+    }
+
+    func goToFinalTutorial() {
+        step = .tutorialFinal
+    }
+
+    func finishTutorial() {
+        onComplete?()
+    }
+
+    var firstDiary: DiaryFeedModel? {
+        tutorialDiaries.first
+    }
+
+    var policyStatusByType: [UserPolicyType: UserPolicyStatus] {
+        Dictionary(uniqueKeysWithValues: initSettings.policies.map { ($0.policyType, $0) })
+    }
+
+    func validateName(_ rawName: String) -> String? {
+        let name = normalizedName(rawName)
+        guard !name.isEmpty else {
+            return "이름을 입력해 주세요."
+        }
+
+        guard (1...20).contains(name.count) else {
+            return "이름은 1자 이상 20자 이하로 입력해 주세요."
+        }
+
+        let pattern = "^[A-Za-z0-9가-힣\\s]+$"
+        if name.range(of: pattern, options: .regularExpression) == nil {
+            return "이름은 영어, 한글, 숫자, 공백만 사용할 수 있어요."
+        }
+
+        return nil
+    }
+
+    func validateTag(_ rawTag: String) -> String? {
+        let tag = normalizedTag(rawTag)
+        guard (4...30).contains(tag.count) else {
+            return "tag는 4자 이상 30자 이하이어야 합니다."
+        }
+
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789_.")
+        if tag.rangeOfCharacter(from: allowed.inverted) != nil {
+            return "영문 소문자, 숫자, '_', '.'만 사용 가능해요."
+        }
+
+        if tag.hasPrefix(".") || tag.hasSuffix(".") || tag.contains("..") {
+            return "'.'으로 시작/끝낼 수 없고 연속 사용은 불가합니다."
+        }
+
+        return nil
+    }
+
+    func normalizedName(_ rawName: String) -> String {
+        rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func normalizedTag(_ rawTag: String) -> String {
+        let trimmed = rawTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("@") {
+            return String(trimmed.dropFirst())
+        }
+        return trimmed
+    }
+
+    private func syncPolicyAgreementState(with settings: UserInitSettingsResponse) {
+        let statusByType = Dictionary(uniqueKeysWithValues: settings.policies.map { ($0.policyType, $0.agreed) })
+        isServiceTermsAgreed = statusByType[.serviceTerms] ?? false
+        isPrivacyAgreed = statusByType[.privacy] ?? false
+    }
+
+    private func applyRefreshedSettingsAfterPolicyAgreement(_ settings: UserInitSettingsResponse) {
+        initSettings = settings
+        syncPolicyAgreementState(with: settings)
+
+        if settings.needsPolicyAgreement {
+            step = .policyAgreement
+            errorMessage = "필수 약관 동의가 완료되지 않았어요."
+            return
+        }
+
+        if settings.needsTagSetup {
+            step = .nameSetup
+            return
+        }
+
+        onComplete?()
+    }
+
+    private func agreementValue(for type: UserPolicyType) -> Bool {
+        switch type {
+        case .serviceTerms:
+            return isServiceTermsAgreed
+        case .privacy:
+            return isPrivacyAgreed
+        }
+    }
+
+    private func resolveErrorMessage(from error: Error) -> String {
+        if let userError = error as? UserServiceError {
+            return userError.errorDescription ?? "요청 처리에 실패했어요."
+        }
+
+        if let apiError = error as? APIClientError {
+            return apiError.errorDescription ?? "요청 처리에 실패했어요."
+        }
+
+        if let localizedError = error as? LocalizedError {
+            return localizedError.errorDescription ?? "요청 처리에 실패했어요."
+        }
+
+        return "요청 처리에 실패했어요."
+    }
+
+    private func isRequestCancelled(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+    }
+
+    private static let currentMonthStartDate: String = {
+        let calendar = Calendar.current
+        let now = Date()
+        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) ?? now
+        return dateFormatter.string(from: start)
+    }()
+
+    private static let currentMonthEndDate: String = {
+        let calendar = Calendar.current
+        let now = Date()
+        let start = calendar.date(from: calendar.dateComponents([.year, .month], from: now)) ?? now
+        let nextMonth = calendar.date(byAdding: .month, value: 1, to: start) ?? now
+        let end = calendar.date(byAdding: .day, value: -1, to: nextMonth) ?? now
+        return dateFormatter.string(from: end)
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = .current
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/AddSearchDetailView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/AddSearchDetailView.swift
@@ -6,19 +6,29 @@ struct AddSearchDetailView: View {
     @StateObject private var viewModel: AddSearchDetailViewModel
     @State private var isForwardStepTransition = true
     @State private var playerReloadToken = UUID()
+    @State private var isTutorialTrimFocusActive = false
     private let onSaved: (() -> Void)?
     private let shouldNavigateToPlayKillingPartOnSave: Bool
     private let onSaveCompletedAfterDismiss: (() -> Void)?
+    private let skipButtonTitle: String?
+    private let onSkip: (() -> Void)?
+    private let isTutorialTrimFocusEnabled: Bool
 
     init(
         track: SpotifySimpleTrack,
         prefill: AddSearchDetailPrefill? = nil,
         shouldNavigateToPlayKillingPartOnSave: Bool = true,
+        skipButtonTitle: String? = nil,
+        onSkip: (() -> Void)? = nil,
+        isTutorialTrimFocusEnabled: Bool = false,
         onSaveCompletedAfterDismiss: (() -> Void)? = nil,
         onSaved: (() -> Void)? = nil
     ) {
         self.onSaved = onSaved
         self.shouldNavigateToPlayKillingPartOnSave = shouldNavigateToPlayKillingPartOnSave
+        self.skipButtonTitle = skipButtonTitle
+        self.onSkip = onSkip
+        self.isTutorialTrimFocusEnabled = isTutorialTrimFocusEnabled
         self.onSaveCompletedAfterDismiss = onSaveCompletedAfterDismiss
         _viewModel = StateObject(
             wrappedValue: AddSearchDetailViewModel(
@@ -29,6 +39,10 @@ struct AddSearchDetailView: View {
     }
 
     var body: some View {
+        let isTrimFocusActive = isTutorialTrimFocusEnabled
+            && isTutorialTrimFocusActive
+            && viewModel.currentStep == .trim
+
         ZStack {
             Color.black.ignoresSafeArea()
 
@@ -38,12 +52,15 @@ struct AddSearchDetailView: View {
                         viewModel: viewModel,
                         playerReloadToken: playerReloadToken
                     )
+                    .opacity(isTrimFocusActive ? 0.35 : 1)
                     AddSearchDetailTrackInfoSection(track: viewModel.track)
+                        .opacity(isTrimFocusActive ? 0.35 : 1)
                     detailInputSection
                         .clipped()
 
                     if viewModel.videos.count > 1 {
                         AddSearchDetailVideoCandidateSection(viewModel: viewModel)
+                            .opacity(isTrimFocusActive ? 0.35 : 1)
                     }
                 }
                 .padding(.horizontal, AppSpacing.l)
@@ -54,13 +71,30 @@ struct AddSearchDetailView: View {
         }
         .safeAreaInset(edge: .bottom) {
             actionBar
+                .opacity(isTrimFocusActive ? 0.35 : 1)
         }
         .task {
             await viewModel.loadIfNeeded()
         }
+        .onAppear {
+            if isTutorialTrimFocusEnabled {
+                isTutorialTrimFocusActive = true
+            }
+        }
         .onChange(of: scenePhase) { phase in
             guard phase == .active else { return }
             playerReloadToken = UUID()
+        }
+        .onChange(of: viewModel.currentStep) { step in
+            if step != .trim {
+                isTutorialTrimFocusActive = false
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if isTrimFocusActive {
+                isTutorialTrimFocusActive = false
+            }
         }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
@@ -72,6 +106,16 @@ struct AddSearchDetailView: View {
                     .scaledToFit()
                     .frame(height: 30)
                     .accessibilityLabel("KillingPart")
+            }
+
+            if let skipButtonTitle, let onSkip {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(skipButtonTitle) {
+                        onSkip()
+                    }
+                    .font(AppFont.paperlogy5Medium(size: 14))
+                    .foregroundStyle(.white)
+                }
             }
         }
     }

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/AddSearchDetailView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/AddSearchDetailView.swift
@@ -48,11 +48,15 @@ struct AddSearchDetailView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: AppSpacing.m) {
-                    AddSearchDetailVideoSection(
-                        viewModel: viewModel,
-                        playerReloadToken: playerReloadToken
-                    )
-                    .opacity(isTrimFocusActive ? 0.35 : 1)
+                    if viewModel.currentStep == .comment && isTutorialTrimFocusEnabled {
+                        commentVideoPlaceholder
+                    } else {
+                        AddSearchDetailVideoSection(
+                            viewModel: viewModel,
+                            playerReloadToken: playerReloadToken
+                        )
+                        .opacity(isTrimFocusActive ? 0.35 : 1)
+                    }
                     AddSearchDetailTrackInfoSection(track: viewModel.track)
                         .opacity(isTrimFocusActive ? 0.35 : 1)
                     detailInputSection
@@ -72,6 +76,19 @@ struct AddSearchDetailView: View {
         .safeAreaInset(edge: .bottom) {
             actionBar
                 .opacity(isTrimFocusActive ? 0.35 : 1)
+        }
+        .safeAreaInset(edge: .top, spacing: AppSpacing.s) {
+            if isTrimFocusActive {
+                Text("킬링파트로 사용할 구간을 정해보세요!")
+                    .font(AppFont.paperlogy7Bold(size: 32))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, AppSpacing.l)
+                    .padding(.top, AppSpacing.s)
+                    .padding(.bottom, AppSpacing.xs)
+                    .transition(.opacity)
+            }
         }
         .task {
             await viewModel.loadIfNeeded()
@@ -184,6 +201,15 @@ struct AddSearchDetailView: View {
         .padding(.top, AppSpacing.s)
         .padding(.bottom, AppSpacing.s)
         .background(Color.black.opacity(0.94))
+    }
+
+    private var commentVideoPlaceholder: some View {
+        Text("선택한 구간에서 느낀\n감정과 생각을 적어보세요.")
+            .font(AppFont.paperlogy6SemiBold(size: 20))
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, AppSpacing.xl)
     }
 
     private var stepTransition: AnyTransition {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoCandidateSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoCandidateSection.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct AddSearchDetailVideoCandidateSection: View {
     @ObservedObject var viewModel: AddSearchDetailViewModel
-    @State private var isExpanded = true
+    @State private var isExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppSpacing.s) {
@@ -16,16 +16,13 @@ struct AddSearchDetailVideoCandidateSection: View {
                         isExpanded.toggle()
                     }
                 } label: {
-                    HStack(spacing: 4) {
-
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 11, weight: .semibold))
-                            .foregroundStyle(.white.opacity(0.78))
-                    }
-                    .padding(.horizontal, AppSpacing.xs)
-                    .padding(.vertical, 6)
-                    .background(Color.white.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.78))
+                        .padding(.horizontal, AppSpacing.xs)
+                        .padding(.vertical, 6)
+                        .background(Color.white.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                 }
                 .buttonStyle(.plain)
 

--- a/KillingPart/Views/Screens/Main/My/MusicCalendar/components/MusicCalendarCalendarSection.swift
+++ b/KillingPart/Views/Screens/Main/My/MusicCalendar/components/MusicCalendarCalendarSection.swift
@@ -6,20 +6,17 @@ struct MusicCalendarCalendarSection: View {
     let onDayTap: (Date) -> Void
 
     var body: some View {
-        Rectangle()
-            .fill(Color.black.opacity(0.28))
-            .overlay {
-                VStack(spacing: AppSpacing.s) {
-                    weekdayHeaderRow
+        VStack(spacing: AppSpacing.s) {
+            weekdayHeaderRow
 
-                    LazyVGrid(columns: calendarGridColumns, spacing: 0) {
-                        ForEach(dayCells) { cell in
-                            dayCell(cell)
-                        }
-                    }
+            LazyVGrid(columns: calendarGridColumns, spacing: 0) {
+                ForEach(dayCells) { cell in
+                    dayCell(cell)
                 }
-                .padding(AppSpacing.m)
             }
+        }
+        .padding(AppSpacing.m)
+        .background(Color.black.opacity(0.28))
     }
 
     private var weekdayHeaderRow: some View {

--- a/KillingPart/Views/Screens/Main/My/MyCollection/Components/ProfileCard/MyCollectionProfileCard.swift
+++ b/KillingPart/Views/Screens/Main/My/MyCollection/Components/ProfileCard/MyCollectionProfileCard.swift
@@ -10,6 +10,7 @@ struct MyCollectionProfileCard: View {
     let onFanStatTap: () -> Void
     let onPickStatTap: () -> Void
     let onEditProfileTap: () -> Void
+    var showEditButton: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: AppSpacing.s) {
@@ -49,7 +50,9 @@ struct MyCollectionProfileCard: View {
                         }
                         .frame(maxWidth: .infinity, alignment: .center)
                     }
-                    MyCollectionEditProfileButton(action: onEditProfileTap)
+                    if showEditButton {
+                        MyCollectionEditProfileButton(action: onEditProfileTap)
+                    }
                 }
             }
 

--- a/KillingPart/Views/Screens/RootFlowView.swift
+++ b/KillingPart/Views/Screens/RootFlowView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct RootFlowView: View {
+    @Environment(\.openURL) private var openURL
     @StateObject private var viewModel = AppViewModel()
 
     var body: some View {
@@ -8,14 +9,65 @@ struct RootFlowView: View {
             switch viewModel.currentStep {
             case .splash:
                 SplashView(onFinished: viewModel.completeSplash)
-            case .onboarding:
-                OnboardingContainerView(onContinue: viewModel.completeOnboarding)
             case .login:
                 LoginView(viewModel: viewModel.loginViewModel)
+            case .setup:
+                if let setupFlowViewModel = viewModel.setupFlowViewModel {
+                    InitialSetupFlowView(viewModel: setupFlowViewModel)
+                } else {
+                    LoginView(viewModel: viewModel.loginViewModel)
+                }
             case .main:
                 MainTabView(onLogout: viewModel.logout)
             }
         }
+        .overlay {
+            if viewModel.isResolvingPostLoginFlow {
+                ZStack {
+                    Color.black.opacity(0.35).ignoresSafeArea()
+                    ProgressView()
+                        .tint(AppColors.primary600)
+                }
+            }
+        }
+        .alert(
+            viewModel.updatePrompt?.title ?? "",
+            isPresented: updatePromptBinding,
+            presenting: viewModel.updatePrompt
+        ) { prompt in
+            switch prompt {
+            case .force:
+                Button("업데이트") {
+                    if let appStoreURL = viewModel.openAppStoreURLForUpdate() {
+                        openURL(appStoreURL)
+                    }
+                }
+            case .optional:
+                Button("나중에") {
+                    viewModel.dismissOptionalUpdatePrompt()
+                }
+                Button("업데이트") {
+                    if let appStoreURL = viewModel.openAppStoreURLForUpdate() {
+                        openURL(appStoreURL)
+                    }
+                    viewModel.dismissOptionalUpdatePrompt()
+                }
+            }
+        } message: { prompt in
+            Text(prompt.message)
+        }
         .animation(.easeInOut(duration: 0.25), value: viewModel.currentStep)
+    }
+
+    private var updatePromptBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.updatePrompt != nil },
+            set: { isPresented in
+                guard !isPresented else { return }
+                if viewModel.updatePrompt == .optional {
+                    viewModel.dismissOptionalUpdatePrompt()
+                }
+            }
+        )
     }
 }

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -543,6 +543,25 @@ private struct TagSetupScreen: View {
     }
 }
 
+private struct InitialSetupSkipButtonRow: View {
+    let onSkip: () -> Void
+
+    var body: some View {
+        HStack {
+            Spacer(minLength: 0)
+            Button("건너뛰기") {
+                onSkip()
+            }
+            .font(AppFont.paperlogy5Medium(size: 14))
+            .foregroundStyle(.white.opacity(0.92))
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.s)
+        .padding(.bottom, AppSpacing.xs)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+}
+
 private struct TutorialChoiceScreen: View {
     @ObservedObject var viewModel: InitialSetupFlowViewModel
 
@@ -563,20 +582,6 @@ private struct TutorialChoiceScreen: View {
                     viewModel.startTutorialTrackSelection()
                 }
                 .padding(.horizontal, AppSpacing.l)
-
-                Button {
-                    viewModel.skipAllTutorialAndFinish()
-                } label: {
-                    Text("건너뛰기")
-                        .font(AppFont.paperlogy6SemiBold(size: 16))
-                        .foregroundStyle(.black)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, AppSpacing.m)
-                        .background(Color.white.opacity(0.65))
-                        .clipShape(RoundedRectangle(cornerRadius: 24))
-                }
-                .buttonStyle(.plain)
-                .padding(.horizontal, AppSpacing.l)
             }
             .padding(.bottom, AppSpacing.xl)
         }
@@ -588,6 +593,9 @@ private struct TutorialChoiceScreen: View {
             )
             .ignoresSafeArea()
         )
+        .safeAreaInset(edge: .top, spacing: 0) {
+            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
+        }
     }
 }
 
@@ -611,16 +619,6 @@ private struct TutorialTrackSearchScreen: View {
                 .ignoresSafeArea()
 
                 VStack(spacing: AppSpacing.m) {
-                    HStack {
-                        Spacer()
-                        Button("건너뛰기") {
-                            onSkip()
-                        }
-                        .font(AppFont.paperlogy5Medium(size: 15))
-                        .foregroundStyle(.white.opacity(0.92))
-                    }
-                    .padding(.top, geometry.safeAreaInsets.top + AppSpacing.s)
-
                     VStack(spacing: 4) {
                         Text("어떤 곡으로 시작할까요?")
                             .font(AppFont.paperlogy8ExtraBold(size: 34))
@@ -649,6 +647,9 @@ private struct TutorialTrackSearchScreen: View {
                 }
                 .padding(.horizontal, AppSpacing.l)
             }
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            InitialSetupSkipButtonRow(onSkip: onSkip)
         }
     }
 
@@ -872,24 +873,17 @@ private struct TutorialHomeScreen: View {
         .onAppear {
             configureSegmentedControlFontIfNeeded()
         }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
+        }
     }
 
     private var header: some View {
-        HStack(alignment: .top) {
-            Text("추가한 킬링파트는\n여기서 다시 볼 수 있어요.")
-                .font(AppFont.paperlogy7Bold(size: 30))
-                .foregroundStyle(.white)
-                .multilineTextAlignment(.leading)
-
-            Spacer(minLength: AppSpacing.s)
-
-            Button("건너뛰기") {
-                viewModel.skipAllTutorialAndFinish()
-            }
-            .buttonStyle(.plain)
-            .font(AppFont.paperlogy5Medium(size: 14))
-            .foregroundStyle(.white.opacity(0.9))
-        }
+        Text("추가한 킬링파트는\n여기서 다시 볼 수 있어요.")
+            .font(AppFont.paperlogy7Bold(size: 30))
+            .foregroundStyle(.white)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var topToggleTabs: some View {
@@ -1267,23 +1261,15 @@ private struct TutorialDiaryDetailScreen: View {
     )
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            NavigationStack {
-                SocialMyCollectionDiary(
-                    diaryId: mockDiary.diaryId,
-                    displayTag: "@KILLINGPART",
-                    diary: mockDiary
-                )
-            }
-
-            Button("건너뛰기") {
-                viewModel.skipAllTutorialAndFinish()
-            }
-            .buttonStyle(.plain)
-            .font(AppFont.paperlogy5Medium(size: 14))
-            .foregroundStyle(.white.opacity(0.9))
-            .padding(.top, AppSpacing.l)
-            .padding(.trailing, AppSpacing.l)
+        NavigationStack {
+            SocialMyCollectionDiary(
+                diaryId: mockDiary.diaryId,
+                displayTag: "@KILLINGPART",
+                diary: mockDiary
+            )
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
         }
         .safeAreaInset(edge: .bottom) {
             PrimaryButton(title: "다음으로") {
@@ -1311,16 +1297,6 @@ private struct TutorialNotificationScreen: View {
 
     var body: some View {
         VStack(spacing: AppSpacing.m) {
-            HStack {
-                Spacer(minLength: 0)
-                Button("건너뛰기") {
-                    viewModel.skipAllTutorialAndFinish()
-                }
-            }
-            .buttonStyle(.plain)
-            .font(AppFont.paperlogy5Medium(size: 14))
-            .foregroundStyle(.white.opacity(0.9))
-
             Text("알림을 통해\n내 픽과 팬덤의 활동을 확인하세요!")
                 .font(AppFont.paperlogy7Bold(size: 30))
                 .foregroundStyle(.white)
@@ -1384,6 +1360,9 @@ private struct TutorialNotificationScreen: View {
             )
             .ignoresSafeArea()
         )
+        .safeAreaInset(edge: .top, spacing: 0) {
+            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
+        }
     }
 }
 

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -198,14 +198,42 @@ private struct PolicyDocumentSheet: View {
 
     let documentType: PolicyDocumentType
 
+    private enum LineStyle {
+        case article
+        case numbered
+        case numberedContinuation
+        case subNumbered
+        case subNumberedContinuation
+        case body
+        case blank
+    }
+
+    private struct StyledLine: Identifiable {
+        let id: Int
+        let text: String
+        let style: LineStyle
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
-                Text(documentType.fullText)
-                    .font(AppFont.paperlogy4Regular(size: 13))
-                    .foregroundStyle(.white.opacity(0.9))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(AppSpacing.l)
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(styledLines) { line in
+                        if line.style == .blank {
+                            Color.clear
+                                .frame(height: 10)
+                        } else {
+                            Text(line.text)
+                                .font(font(for: line.style))
+                                .foregroundStyle(.white.opacity(0.92))
+                                .lineSpacing(4)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.leading, leadingInset(for: line.style))
+                                .padding(.top, topInset(for: line.style))
+                        }
+                    }
+                }
+                .padding(AppSpacing.l)
             }
             .background(Color.black.ignoresSafeArea())
             .navigationTitle(documentType.title)
@@ -218,6 +246,129 @@ private struct PolicyDocumentSheet: View {
                     .foregroundStyle(.white)
                 }
             }
+        }
+    }
+
+    private var styledLines: [StyledLine] {
+        let lines = normalizedDocumentText.components(separatedBy: .newlines)
+        var result: [StyledLine] = []
+        var previousStyle: LineStyle = .blank
+
+        for (index, rawLine) in lines.enumerated() {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            let baseStyle = style(for: trimmed)
+
+            let resolvedStyle: LineStyle
+            if baseStyle == .body {
+                switch previousStyle {
+                case .numbered, .numberedContinuation:
+                    resolvedStyle = .numberedContinuation
+                case .subNumbered, .subNumberedContinuation:
+                    resolvedStyle = .subNumberedContinuation
+                default:
+                    resolvedStyle = .body
+                }
+            } else {
+                resolvedStyle = baseStyle
+            }
+
+            result.append(
+                StyledLine(
+                    id: index,
+                    text: trimmed,
+                    style: resolvedStyle
+                )
+            )
+            previousStyle = resolvedStyle
+        }
+        return result
+    }
+
+    private var normalizedDocumentText: String {
+        var text = documentType.fullText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "## ", with: "")
+        text = text.replacingOccurrences(
+            of: #"\)(\d+\.)"#,
+            with: ")\n$1",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(
+            of: #"(\d+년)(\d+\.)"#,
+            with: "$1\n$2",
+            options: .regularExpression
+        )
+        return text
+    }
+
+    private func style(for line: String) -> LineStyle {
+        if line.isEmpty {
+            return .blank
+        }
+        if line.range(of: #"^제\d+조"#, options: .regularExpression) != nil || line == "부칙" {
+            return .article
+        }
+        if line.range(of: #"^\d+[.)]"#, options: .regularExpression) != nil {
+            return .numbered
+        }
+        if line.range(of: #"^[가-하][.)]"#, options: .regularExpression) != nil {
+            return .subNumbered
+        }
+        return .body
+    }
+
+    private func font(for style: LineStyle) -> Font {
+        switch style {
+        case .article:
+            return AppFont.paperlogy7Bold(size: 18)
+        case .numbered:
+            return AppFont.paperlogy5Medium(size: 14)
+        case .numberedContinuation:
+            return AppFont.paperlogy5Medium(size: 14)
+        case .subNumbered:
+            return AppFont.paperlogy5Medium(size: 13)
+        case .subNumberedContinuation:
+            return AppFont.paperlogy5Medium(size: 13)
+        case .body:
+            return AppFont.paperlogy4Regular(size: 13)
+        case .blank:
+            return AppFont.paperlogy4Regular(size: 13)
+        }
+    }
+
+    private func leadingInset(for style: LineStyle) -> CGFloat {
+        switch style {
+        case .article:
+            return 0
+        case .numbered:
+            return 10
+        case .numberedContinuation:
+            return 30
+        case .subNumbered:
+            return 20
+        case .subNumberedContinuation:
+            return 40
+        case .body, .blank:
+            return 0
+        }
+    }
+
+    private func topInset(for style: LineStyle) -> CGFloat {
+        switch style {
+        case .article:
+            return 12
+        case .numbered:
+            return 6
+        case .numberedContinuation:
+            return 2
+        case .subNumbered:
+            return 4
+        case .subNumberedContinuation:
+            return 2
+        case .body:
+            return 3
+        case .blank:
+            return 0
         }
     }
 }
@@ -1244,8 +1395,6 @@ private struct TutorialFinalScreen: View {
 
 private enum PolicyDocumentContent {
     static let privacyPolicy = """
-개인정보 처리방침
-
 제1조(목적)
 킬링파트(이하 ‘회사'라고 함)는 회사가 제공하고자 하는 서비스(이하 ‘회사 서비스’)를 이용하는 개인(이하 ‘이용자’ 또는 ‘개인’)의 정보(이하 ‘개인정보’)를 보호하기 위해, 개인정보보호법, 정보통신망 이용촉진 및 정보보호 등에 관한 법률(이하 '정보통신망법') 등 관련 법령을 준수하고, 서비스 이용자의 개인정보 보호 관련한 고충을 신속하고 원활하게 처리할 수 있도록 하기 위하여 다음과 같이 개인정보처리방침(이하 ‘본 방침’)을 수립합니다.
 
@@ -1503,24 +1652,6 @@ private enum PolicyDocumentContent {
 """
 
     static let serviceTerms = """
-서비스 이용 약관
-- 시행일자 : 2026.03.18
-    
-    서비스 공급자 : 킬링파트
-    
-    무료 서비스만 제공 중
-    
-    회원가입 승낙 및 제약조건 : 없음
-    
-    제공하는 서비스 내역 : 음악 콘텐츠의 특정 구간 기록 및 저장 기능 / 킬링파트 관련 게시물 작성, 편집, 공개, 공유 기능 / 다른 이용자가 작성한 킬링파트 및 관련 콘텐츠의 탐색, 조회 기능 / 모바일 애플리케이션 및 기타 전자적 방식으로 제공되는 관련 제반 서비스 → 별도 첨부 X
-    
-    광고성 정보 수신 여부 : 예 → 추후 영리 목적으로 광고성 정보 수신 여부 목적, 이용약관과 별개로 따로 받아야 함.
-    
-    게시물의 관리 및 지식 재산권 여부 : 예 (콘텐츠 작성 여부 / 당사가 이용자가 만든 컨텐츠를 자유롭게 사용 가능 → 2차적 저작물 또는 편집 저작물 작성, 서비스 개선 및 새로운 서비스 개발, 미디어, 통신사 등을 통한 홍보 목적)
-    
-    민사소송법에 따른 관할법원에 따름ㅅ
-    
-
 ## 제1조(목적)
 
 이 약관은 킬링파트 (이하 '회사' 라고 합니다)가 제공하는 제반 서비스의 이용과 관련하여 회사와 회원과의

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -392,17 +392,16 @@ private struct NameSetupScreen: View {
             VStack(spacing: 0) {
                 VStack(alignment: .leading, spacing: AppSpacing.s) {
                     Text("사용하실 이름이 무엇인가요?")
-                        .font(AppFont.paperlogy7Bold(size: 28))
+                        .font(AppFont.paperlogy7Bold(size: 24))
                         .foregroundStyle(.white)
 
                     Text("이름은 언제든지 바꿀 수 있습니다")
                         .font(AppFont.paperlogy4Regular(size: 14))
-                        .foregroundStyle(.white.opacity(0.72))
+                        .foregroundStyle(.white)
 
-                    Text("*이름은 1~20자, 영어/한글/숫자/공백만 사용 가능")
+                    Text("*한글 8자 이내, 영어 16자 이내(숫자 포함)")
                         .font(AppFont.paperlogy4Regular(size: 12))
                         .foregroundStyle(.white.opacity(0.55))
-                        .padding(.top, AppSpacing.xs)
 
                     TextField("이름 입력", text: $viewModel.nameDraft)
                         .font(AppFont.paperlogy5Medium(size: 16))
@@ -460,65 +459,78 @@ private struct TagSetupScreen: View {
     @ObservedObject var viewModel: InitialSetupFlowViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: AppSpacing.s) {
-                Text("개성을 나타내는 태그를 정해주세요")
-                    .font(AppFont.paperlogy7Bold(size: 28))
-                    .foregroundStyle(.white)
+        GeometryReader { geometry in
+            let horizontalPadding = AppSpacing.l
+            let safeAreaBottomInset = geometry.safeAreaInsets.bottom
+            let isKeyboardPresented = safeAreaBottomInset > 80
+            let bottomPadding = isKeyboardPresented
+                ? AppSpacing.s
+                : safeAreaBottomInset + AppSpacing.l
+            let contentTopOffset = max(
+                geometry.safeAreaInsets.top + AppSpacing.xl,
+                geometry.size.height * 0.22
+            )
 
-                Text("언제든지 바꿀 수 있습니다")
-                    .font(AppFont.paperlogy4Regular(size: 14))
-                    .foregroundStyle(.white.opacity(0.72))
-
-                Text("*영문 소문자, 숫자, '_', '.' / 4~30자")
-                    .font(AppFont.paperlogy4Regular(size: 12))
-                    .foregroundStyle(.white.opacity(0.55))
-                    .padding(.top, AppSpacing.xs)
-
-                HStack(spacing: AppSpacing.xs) {
-                    Text("@")
-                        .font(AppFont.paperlogy5Medium(size: 18))
-                        .foregroundStyle(.white.opacity(0.7))
-                    TextField("태그 입력", text: $viewModel.tagDraft)
-                        .font(AppFont.paperlogy5Medium(size: 16))
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: AppSpacing.s) {
+                    Text("개성을 나타내는 태그를 정해주세요")
+                        .font(AppFont.paperlogy7Bold(size: 24))
                         .foregroundStyle(.white)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                }
-                .padding(.horizontal, AppSpacing.m)
-                .padding(.vertical, AppSpacing.m)
-                .background(Color.white.opacity(0.08))
-                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 18, style: .continuous)
-                        .stroke(Color.white.opacity(0.1), lineWidth: 1)
-                }
 
-                if let validation = viewModel.validateTag(viewModel.tagDraft), !viewModel.tagDraft.isEmpty {
-                    Text(validation)
-                        .font(AppFont.paperlogy4Regular(size: 13))
-                        .foregroundStyle(.red.opacity(0.95))
-                } else if let errorMessage = viewModel.errorMessage {
-                    Text(errorMessage)
-                        .font(AppFont.paperlogy4Regular(size: 13))
-                        .foregroundStyle(.red.opacity(0.95))
+                    Text("언제든지 바꿀 수 있습니다")
+                        .font(AppFont.paperlogy4Regular(size: 14))
+                        .foregroundStyle(.white)
+
+                    Text("*영문 소문자 4이상, 30자 이내, 특수문자 일부[.][_]")
+                        .font(AppFont.paperlogy4Regular(size: 12))
+                        .foregroundStyle(.white.opacity(0.55))
+                        
+
+                    HStack(spacing: AppSpacing.xs) {
+                        Text("@")
+                            .font(AppFont.paperlogy5Medium(size: 18))
+                            .foregroundStyle(.white.opacity(0.7))
+                        TextField("태그 입력", text: $viewModel.tagDraft)
+                            .font(AppFont.paperlogy5Medium(size: 16))
+                            .foregroundStyle(.white)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    }
+                    .padding(.horizontal, AppSpacing.m)
+                    .padding(.vertical, AppSpacing.m)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                    }
+
+                    if let validation = viewModel.validateTag(viewModel.tagDraft), !viewModel.tagDraft.isEmpty {
+                        Text(validation)
+                            .font(AppFont.paperlogy4Regular(size: 13))
+                            .foregroundStyle(.red.opacity(0.95))
+                    } else if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(AppFont.paperlogy4Regular(size: 13))
+                            .foregroundStyle(.red.opacity(0.95))
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.top, contentTopOffset)
+
+                Spacer(minLength: 0)
+
+                PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
+                    Task {
+                        await viewModel.submitTag()
+                    }
+                }
+                .disabled(!viewModel.canSubmitTag || viewModel.isLoading)
+                .opacity((viewModel.canSubmitTag && !viewModel.isLoading) ? 1 : 0.45)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.bottom, bottomPadding)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, AppSpacing.l)
-            .padding(.top, AppSpacing.xl)
-
-            Spacer(minLength: 0)
-
-            PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
-                Task {
-                    await viewModel.submitTag()
-                }
-            }
-            .disabled(!viewModel.canSubmitTag || viewModel.isLoading)
-            .opacity((viewModel.canSubmitTag && !viewModel.isLoading) ? 1 : 0.45)
-            .padding(.horizontal, AppSpacing.l)
-            .padding(.bottom, AppSpacing.xl)
         }
         .background(
             LinearGradient(

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -60,6 +60,7 @@ private struct PolicyAgreementScreen: View {
             let horizontalPadding = max(AppSpacing.m, geometry.size.width * 0.08)
             let topPadding = geometry.safeAreaInsets.top + AppSpacing.l
             let bottomPadding = geometry.safeAreaInsets.bottom + AppSpacing.l
+            let titleTopOffset = max(topPadding + AppSpacing.xl, geometry.size.height * 0.18)
 
             ZStack {
                 LoginBackgroundVideoView()
@@ -73,13 +74,17 @@ private struct PolicyAgreementScreen: View {
                 .ignoresSafeArea()
 
                 VStack(spacing: 0) {
+                    Image("loginTitle")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: min(geometry.size.width * 0.62, 280))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, horizontalPadding)
+                        .padding(.top, titleTopOffset)
+
                     Spacer(minLength: 0)
 
                     VStack(alignment: .leading, spacing: AppSpacing.m) {
-                        Text("짧게 들어도, 길게 남는 순간")
-                            .font(AppFont.paperlogy5Medium(size: 24))
-                            .foregroundStyle(.white)
-
                         policyRow(
                             title: "서비스 이용약관",
                             isChecked: viewModel.isServiceTermsAgreed,
@@ -124,7 +129,6 @@ private struct PolicyAgreementScreen: View {
                     .padding(.horizontal, horizontalPadding)
                     .padding(.bottom, bottomPadding)
                 }
-                .padding(.top, topPadding)
             }
         }
         .sheet(item: $activeDocument) { documentType in

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -582,6 +582,20 @@ private struct TutorialChoiceScreen: View {
                     viewModel.startTutorialTrackSelection()
                 }
                 .padding(.horizontal, AppSpacing.l)
+
+                Button {
+                    viewModel.skipAllTutorialAndFinish()
+                } label: {
+                    Text("건너뛰기")
+                        .font(AppFont.paperlogy6SemiBold(size: 16))
+                        .foregroundStyle(.black.opacity(0.9))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, AppSpacing.m)
+                        .background(Color.white.opacity(0.65))
+                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, AppSpacing.l)
             }
             .padding(.bottom, AppSpacing.xl)
         }
@@ -593,9 +607,6 @@ private struct TutorialChoiceScreen: View {
             )
             .ignoresSafeArea()
         )
-        .safeAreaInset(edge: .top, spacing: 0) {
-            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
-        }
     }
 }
 
@@ -621,7 +632,7 @@ private struct TutorialTrackSearchScreen: View {
                 VStack(spacing: AppSpacing.m) {
                     VStack(spacing: 4) {
                         Text("어떤 곡으로 시작할까요?")
-                            .font(AppFont.paperlogy8ExtraBold(size: 34))
+                            .font(AppFont.paperlogy8ExtraBold(size: 30))
                             .foregroundStyle(.white)
                         Text("킬링파트 제작하기")
                             .font(AppFont.paperlogy4Regular(size: 15))
@@ -646,6 +657,7 @@ private struct TutorialTrackSearchScreen: View {
                         )
                 }
                 .padding(.horizontal, AppSpacing.l)
+                .padding(.top, AppSpacing.l)
             }
         }
         .safeAreaInset(edge: .top, spacing: 0) {
@@ -880,10 +892,10 @@ private struct TutorialHomeScreen: View {
 
     private var header: some View {
         Text("추가한 킬링파트는\n여기서 다시 볼 수 있어요.")
-            .font(AppFont.paperlogy7Bold(size: 30))
+            .font(AppFont.paperlogy7Bold(size: 24))
             .foregroundStyle(.white)
-            .multilineTextAlignment(.leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private var topToggleTabs: some View {
@@ -930,7 +942,7 @@ private struct TutorialHomeScreen: View {
     @ViewBuilder
     private var collectionContent: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: AppSpacing.m) {
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
                 MyCollectionProfileCard(
                     displayName: viewModel.displayName,
                     displayTag: viewModel.displayTag,
@@ -940,7 +952,8 @@ private struct TutorialHomeScreen: View {
                     pickStatText: "0",
                     onFanStatTap: {},
                     onPickStatTap: {},
-                    onEditProfileTap: {}
+                    onEditProfileTap: {},
+                    showEditButton: false
                 )
                 .background(Color.black.opacity(0.74))
                 .clipShape(RoundedRectangle(cornerRadius: 18))
@@ -997,61 +1010,61 @@ private struct TutorialHomeScreen: View {
     }
 
     private var calendarContent: some View {
-        VStack(alignment: .leading, spacing: AppSpacing.m) {
-            MusicCalendarHeaderSection(
-                yearText: "\(year(from: displayedMonth))년",
-                monthText: "\(month(from: displayedMonth))월",
-                onMonthTap: {},
-                onPreviousMonthTap: {
-                    guard let movedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) else { return }
-                    displayedMonth = Self.startOfMonth(for: movedMonth)
-                    selectedDate = displayedMonth
-                },
-                onNextMonthTap: {
-                    guard let movedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) else { return }
-                    displayedMonth = Self.startOfMonth(for: movedMonth)
-                    selectedDate = displayedMonth
-                }
-            )
-
-            MusicCalendarCalendarSection(
-                weekdayTitles: ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"],
-                dayCells: calendarDayCells,
-                onDayTap: { date in
-                    withAnimation(.easeInOut(duration: 0.24)) {
-                        selectedDate = date
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.m) {
+                MusicCalendarHeaderSection(
+                    yearText: "\(year(from: displayedMonth))년",
+                    monthText: "\(month(from: displayedMonth))월",
+                    onMonthTap: {},
+                    onPreviousMonthTap: {
+                        guard let movedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) else { return }
+                        displayedMonth = Self.startOfMonth(for: movedMonth)
+                        selectedDate = displayedMonth
+                    },
+                    onNextMonthTap: {
+                        guard let movedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) else { return }
+                        displayedMonth = Self.startOfMonth(for: movedMonth)
+                        selectedDate = displayedMonth
                     }
+                )
+
+                MusicCalendarCalendarSection(
+                    weekdayTitles: ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"],
+                    dayCells: calendarDayCells,
+                    onDayTap: { date in
+                        withAnimation(.easeInOut(duration: 0.24)) {
+                            selectedDate = date
+                        }
+                    }
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
                 }
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 14))
-            .overlay {
-                RoundedRectangle(cornerRadius: 14)
-                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
-            }
 
-            VStack(alignment: .leading, spacing: AppSpacing.s) {
-                Text(selectedDateTitle)
-                    .font(AppFont.paperlogy6SemiBold(size: 16))
-                    .foregroundStyle(.white)
+                VStack(alignment: .leading, spacing: AppSpacing.s) {
+                    Text(selectedDateTitle)
+                        .font(AppFont.paperlogy6SemiBold(size: 16))
+                        .foregroundStyle(.white)
 
-                if diariesForSelectedDate.isEmpty {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.white.opacity(0.06))
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 74)
-                        .overlay {
-                            Text("선택한 날짜의 킬링파트가 없어요.")
-                                .font(AppFont.paperlogy4Regular(size: 13))
-                                .foregroundStyle(.white.opacity(0.72))
-                        }
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.white.opacity(0.12), lineWidth: 1)
-                        }
-                } else {
-                    ScrollView {
+                    if diariesForSelectedDate.isEmpty {
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.white.opacity(0.06))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 74)
+                            .overlay {
+                                Text("선택한 날짜의 킬링파트가 없어요.")
+                                    .font(AppFont.paperlogy4Regular(size: 13))
+                                    .foregroundStyle(.white.opacity(0.72))
+                            }
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                            }
+                    } else {
                         LazyVStack(spacing: AppSpacing.xs) {
-                            ForEach(diariesForSelectedDate.prefix(4)) { diary in
+                            ForEach(diariesForSelectedDate) { diary in
                                 MusicCalendarDiaryRow(diary: diary)
                                     .background(Color.black.opacity(0.62))
                                     .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -1061,12 +1074,12 @@ private struct TutorialHomeScreen: View {
                                     }
                             }
                         }
-                        .padding(.bottom, AppSpacing.xs)
                     }
-                    .scrollIndicators(.hidden)
                 }
             }
+            .padding(.bottom, AppSpacing.s)
         }
+        .scrollIndicators(.hidden)
     }
 
     private var profileImageURL: URL? {
@@ -1237,39 +1250,162 @@ private enum TutorialHomeTab: CaseIterable {
 private struct TutorialDiaryDetailScreen: View {
     @ObservedObject var viewModel: InitialSetupFlowViewModel
 
-    private let mockDiary = DiaryFeedModel(
-        diaryId: 999_001,
-        artist: "Davinci Leo",
-        musicTitle: "Death Sonnet von Dat",
-        albumImageUrl: "https://i.imgur.com/8T0h6Zx.png",
-        content: "오늘 하루는 유난히 공허하게 흘러간 것 같다. 해야 할 일은 분명 있었지만 마음은 잘 따라주지 않았고, 생각들은 제자리를 맴돌았다. 그러다 문득, 특별한 이유 없이 음악을 들어야겠다는 충동이 찾아왔다.",
-        videoUrl: "https://www.youtube.com/embed/J---aiyznGQ?playsinline=1",
-        scope: .public,
-        duration: "00:30",
-        totalDuration: "03:24",
-        start: "00:20",
-        end: "00:50",
-        createDate: "2026-05-01T00:00:00",
-        updateDate: "2026-05-01T00:00:00",
-        isLiked: true,
-        isStored: false,
-        likeCount: 26,
-        userId: 9_999,
-        username: "킬링파트",
-        tag: "KILLINGPART",
-        profileImageUrl: nil
-    )
+    private let mockDiaryContent = "오늘 하루는 유난히 공허하게 흘러간 것 같다. 해야 할 일은 분명 있었지만 마음은 잘 따라주지 않았고, 생각들은 제자리를 맴돌았다. 그러다 문득, 특별한 이유 없이 음악을 들어야겠다는 충동이 찾아왔다. 그래서 큰 고민도 없이 ‘아무 노래’를 골랐다..."
 
     var body: some View {
-        NavigationStack {
-            SocialMyCollectionDiary(
-                diaryId: mockDiary.diaryId,
-                displayTag: "@KILLINGPART",
-                diary: mockDiary
-            )
+        ScrollView {
+            VStack(spacing: AppSpacing.m) {
+                Text("피드에서 친구의 킬링파트를,\n탐색에서 다양한 킬링파트를 감상해보세요")
+                    .font(AppFont.paperlogy7Bold(size: 20))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(6)
+                    .padding(.top, AppSpacing.s)
+
+                VStack(spacing: AppSpacing.m) {
+                    HStack(alignment: .center, spacing: AppSpacing.m) {
+                        tutorialProfileImage
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("킬링파트")
+                                .font(AppFont.paperlogy7Bold(size: 15))
+                                .foregroundStyle(AppColors.primary600)
+                            Text("@KILLINGPART")
+                                .font(AppFont.paperlogy4Regular(size: 13))
+                                .foregroundStyle(AppColors.primary600)
+                        }
+                        Spacer(minLength: 0)
+                        Text("프로필 방문")
+                            .font(AppFont.paperlogy5Medium(size: 13))
+                            .foregroundStyle(AppColors.primary600)
+                            .padding(.horizontal, AppSpacing.s)
+                            .padding(.vertical, 6)
+                            .background(Color.white.opacity(0.14))
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    }
+
+                    VStack(spacing: AppSpacing.s) {
+                        tutorialVideoPreview
+
+                        Text("Death Sonnet von Dat")
+                            .font(AppFont.paperlogy7Bold(size: 18))
+                            .foregroundStyle(.white.opacity(0.88))
+                            .frame(maxWidth: .infinity, alignment: .center)
+
+                        Text("Davinci Leo")
+                            .font(AppFont.paperlogy4Regular(size: 15))
+                            .foregroundStyle(.white.opacity(0.56))
+                            .frame(maxWidth: .infinity, alignment: .center)
+
+                        HStack {
+                            Text("킬링파트 일기")
+                                .font(AppFont.paperlogy7Bold(size: 14))
+                                .multilineTextAlignment(.center)
+                                .foregroundStyle(.white.opacity(0.45))
+                                
+                            Spacer(minLength: 0)
+                            HStack(spacing: 5) {
+                                Image(systemName: "heart.fill")
+                                Text("26")
+                            }
+                            .font(AppFont.paperlogy6SemiBold(size: 14))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, AppSpacing.s)
+                            .padding(.vertical, 6)
+                            .background(AppColors.primary600.opacity(0.85))
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        }
+
+                        Text(mockDiaryContent)
+                            .font(AppFont.paperlogy4Regular(size: 14))
+                            .foregroundStyle(.white.opacity(0.5))
+                            .lineSpacing(5)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                            Text("킬링파트")
+                                .font(AppFont.paperlogy5Medium(size: 13))
+                                .foregroundStyle(.white.opacity(0.36))
+                            // 전체 곡: 2:00 (120s), 킬링파트: 1:40 (100s) ~ 2:00 (120s)
+                            // 시작 오프셋 = 100/120 ≈ 83.3%, 구간 폭 = 20/120 ≈ 16.7%
+                            GeometryReader { geo in
+                                let totalWidth = geo.size.width
+                                let startFrac: CGFloat = 100.0 / 120.0
+                                let segmentFrac: CGFloat = 20.0 / 120.0
+                                ZStack(alignment: .leading) {
+                                    Capsule()
+                                        .fill(Color.white.opacity(0.18))
+                                        .frame(height: 3)
+                                    Capsule()
+                                        .fill(
+                                            LinearGradient(
+                                                colors: [AppColors.primary600.opacity(0.7), AppColors.primary600],
+                                                startPoint: .leading,
+                                                endPoint: .trailing
+                                            )
+                                        )
+                                        .frame(width: totalWidth * segmentFrac, height: 8)
+                                        .offset(x: totalWidth * startFrac)
+                                }
+                            }
+                            .frame(height: 8)
+                            HStack(spacing: 2) {
+                                Text("0:00")
+                                    .foregroundStyle(.white.opacity(0.26))
+                                Spacer(minLength: 0)
+                                Text("1:40")
+                                    .foregroundStyle(AppColors.primary600.opacity(0.9))
+                                Text("~")
+                                    .foregroundStyle(AppColors.primary600.opacity(0.6))
+                                Text("2:00")
+                                    .foregroundStyle(AppColors.primary600.opacity(0.9))
+                            }
+                            .font(AppFont.paperlogy4Regular(size: 12))
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(AppSpacing.m)
+                        .background(Color.black.opacity(0.5))
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                        }
+                    }
+                }
+                .padding(AppSpacing.m)
+                .background(Color.black.opacity(0.78))
+                .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.bottom, AppSpacing.xl)
         }
+        .scrollIndicators(.hidden)
+        .background(
+            Image("my_background")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+        )
         .safeAreaInset(edge: .top, spacing: 0) {
-            InitialSetupSkipButtonRow(onSkip: viewModel.skipAllTutorialAndFinish)
+            HStack {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 22, weight: .light))
+                    .foregroundStyle(.white)
+                Spacer(minLength: 0)
+                Button("건너뛰기") {
+                    viewModel.skipAllTutorialAndFinish()
+                }
+                .font(AppFont.paperlogy5Medium(size: 14))
+                .foregroundStyle(.white.opacity(0.92))
+            }
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.top, AppSpacing.s)
+            .padding(.bottom, AppSpacing.xs)
+            .background(Color.clear)
         }
         .safeAreaInset(edge: .bottom) {
             PrimaryButton(title: "다음으로") {
@@ -1281,77 +1417,163 @@ private struct TutorialDiaryDetailScreen: View {
             .background(Color.black.opacity(0.92))
         }
     }
+
+    private var tutorialProfileImage: some View {
+        Circle()
+            .fill(Color.white.opacity(0.2))
+            .overlay {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 22, weight: .light))
+                    .foregroundStyle(.white.opacity(0.85))
+            }
+            .frame(width: 52, height: 52)
+            .overlay {
+                Circle()
+                    .stroke(AppColors.primary600, lineWidth: 3)
+            }
+    }
+
+    private var tutorialVideoPreview: some View {
+        Color.clear
+            .aspectRatio(16 / 9, contentMode: .fit)
+            .overlay {
+                ZStack {
+                    AsyncImage(url: URL(string: "https://picsum.photos/seed/mountain/800/450")) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        case .empty, .failure:
+                            Rectangle()
+                                .fill(Color.white.opacity(0.1))
+                        @unknown default:
+                            Rectangle()
+                                .fill(Color.white.opacity(0.1))
+                        }
+                    }
+
+                    Color.black.opacity(0.3)
+
+                    VStack {
+                        HStack(alignment: .top) {
+                            Text("Death Sonnet von\nDat - Davinci")
+                                .font(AppFont.paperlogy4Regular(size: 16))
+                                .foregroundStyle(.white)
+                                .multilineTextAlignment(.leading)
+                            Spacer(minLength: 0)
+                            Image(systemName: "info.circle.fill")
+                                .font(.system(size: 28, weight: .regular))
+                                .foregroundStyle(.white.opacity(0.92))
+                        }
+                        Spacer(minLength: 0)
+                        Image(systemName: "play.rectangle.fill")
+                            .font(.system(size: 52, weight: .regular))
+                            .foregroundStyle(.red.opacity(0.92))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, AppSpacing.m)
+                    .padding(.vertical, AppSpacing.m)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
 }
 
 private struct TutorialNotificationScreen: View {
     @ObservedObject var viewModel: InitialSetupFlowViewModel
 
+    private let noticeText = "[공지] 신규 업데이트 3.1 예정입니다!"
     private let mockNotifications: [(String, String)] = [
-        ("[공지] 신규 업데이트 3.1 예정입니다!", ""),
         ("OOO님이 회원님을 픽했어요", "04.15"),
         ("OOO의 새로운 업데이트가 배포되었어요", "04.16"),
         ("OOO님이 최근 활동을 공유했어요", "04.16"),
         ("OOO의 이벤트에 초대받았어요", "04.17"),
-        ("OOO님과의 대화가 시작되었어요", "04.17")
+        ("OOO님과의 대화가 시작되었어요", "04.17"),
+        ("OOO의 추천을 받았어요", "04.18"),
+        ("OOO님이 나를 태그했어요", "04.18"),
+        ("OOO의 팬이 되었어요", "04.19"),
+        ("OOO의 킬링파트가 좋아요를 받았어요", "04.15"),
+        ("OOO님이 회원님을 픽했어요", "04.15"),
+        ("OOO의 새로운 업데이트가 배포되었어요", "04.16"),
+        ("OOO의 이벤트에 초대받았어요", "04.17")
     ]
 
     var body: some View {
-        VStack(spacing: AppSpacing.m) {
-            Text("알림을 통해\n내 픽과 팬덤의 활동을 확인하세요!")
-                .font(AppFont.paperlogy7Bold(size: 30))
-                .foregroundStyle(.white)
-                .multilineTextAlignment(.center)
+        GeometryReader { geometry in
+            VStack(spacing: AppSpacing.m) {
+                Text("알림을 통해\n내 픽과 팬덤의 활동을 확인하세요!")
+                    .font(AppFont.paperlogy7Bold(size: 24))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
 
-            VStack(alignment: .leading, spacing: AppSpacing.s) {
-                HStack(spacing: AppSpacing.s) {
-                    Image(systemName: "bell")
-                        .font(.system(size: 22, weight: .semibold))
-                    Text("알림 목록")
-                        .font(AppFont.paperlogy7Bold(size: 24))
-                }
-                .foregroundStyle(AppColors.primary600)
-
-                ForEach(Array(mockNotifications.enumerated()), id: \.offset) { index, row in
-                    if index == 0 {
-                        Text(row.0)
-                            .font(AppFont.paperlogy6SemiBold(size: 17))
-                            .foregroundStyle(.black)
-                            .padding(.horizontal, AppSpacing.m)
-                            .padding(.vertical, AppSpacing.m)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(AppColors.primary600)
-                            .clipShape(RoundedRectangle(cornerRadius: 14))
-                    } else {
-                        HStack {
-                            Text(row.0)
-                                .font(AppFont.paperlogy4Regular(size: 15))
-                                .foregroundStyle(.white.opacity(0.85))
-                            Spacer(minLength: AppSpacing.s)
-                            Text(row.1)
-                                .font(AppFont.paperlogy4Regular(size: 14))
-                                .foregroundStyle(.white.opacity(0.7))
-                        }
-                        .padding(.vertical, AppSpacing.xs)
+                VStack(alignment: .leading, spacing: AppSpacing.m) {
+                    HStack(spacing: AppSpacing.xs) {
+                        Image(systemName: "bell")
+                            .font(.system(size: 16, weight: .semibold))
+                        Text("알림 목록")
+                            .font(AppFont.paperlogy7Bold(size: 18))
                     }
+                    .foregroundStyle(AppColors.primary600)
+                    .frame(maxWidth: .infinity, alignment: .center)
+
+                    Text(noticeText)
+                        .font(AppFont.paperlogy6SemiBold(size: 16))
+                        .foregroundStyle(.black)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, AppSpacing.m)
+                        .padding(.vertical, AppSpacing.m)
+                        .frame(maxWidth: .infinity)
+                        .background(AppColors.primary600)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+
+                    ZStack(alignment: .bottom) {
+                        ScrollView {
+                            LazyVStack(spacing: AppSpacing.xs) {
+                                ForEach(Array(mockNotifications.enumerated()), id: \.offset) { _, row in
+                                    HStack {
+                                        Text(row.0)
+                                            .font(AppFont.paperlogy4Regular(size: 15))
+                                            .foregroundStyle(.white.opacity(0.85))
+                                        Spacer(minLength: AppSpacing.s)
+                                        Text(row.1)
+                                            .font(AppFont.paperlogy4Regular(size: 14))
+                                            .foregroundStyle(.white.opacity(0.7))
+                                    }
+                                    .padding(.vertical, AppSpacing.xs)
+                                }
+                            }
+                            .padding(.bottom, AppSpacing.xl * 2)
+                        }
+                        .scrollIndicators(.hidden)
+
+                        LinearGradient(
+                            colors: [Color.clear, Color.black.opacity(0.95)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 110)
+                        .allowsHitTesting(false)
+                    }
+                    .frame(maxHeight: .infinity)
+                }
+                .padding(AppSpacing.m)
+                .frame(maxHeight: max(geometry.size.height * 0.58, 460))
+                .background(Color.black.opacity(0.72))
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                }
+
+                PrimaryButton(title: "다음으로") {
+                    viewModel.goToFinalTutorial()
                 }
             }
-            .padding(AppSpacing.m)
-            .background(Color.black.opacity(0.72))
-            .clipShape(RoundedRectangle(cornerRadius: 18))
-            .overlay {
-                RoundedRectangle(cornerRadius: 18)
-                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
-            }
-
-            Spacer(minLength: 0)
-
-            PrimaryButton(title: "다음으로") {
-                viewModel.goToFinalTutorial()
-            }
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.top, AppSpacing.l)
+            .padding(.bottom, AppSpacing.l)
         }
-        .padding(.horizontal, AppSpacing.l)
-        .padding(.top, AppSpacing.l)
-        .padding(.bottom, AppSpacing.l)
         .background(
             LinearGradient(
                 colors: [Color.black, Color(hex: "#171A24")],
@@ -1374,7 +1596,7 @@ private struct TutorialFinalScreen: View {
             Spacer(minLength: 0)
 
             Text("이제 킬링파트를\n시작해보세요.")
-                .font(AppFont.paperlogy7Bold(size: 38))
+                .font(AppFont.paperlogy7Bold(size: 32))
                 .foregroundStyle(.white)
                 .multilineTextAlignment(.center)
 

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -1,0 +1,1695 @@
+import SwiftUI
+import UIKit
+
+struct InitialSetupFlowView: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        ZStack {
+            stepContent(for: viewModel.step)
+                .id(viewModel.step)
+                .transition(
+                    .asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .leading).combined(with: .opacity)
+                    )
+                )
+        }
+        .preferredColorScheme(.dark)
+        .animation(.easeInOut(duration: 0.28), value: viewModel.step)
+    }
+
+    @ViewBuilder
+    private func stepContent(for step: InitialSetupFlowViewModel.Step) -> some View {
+        switch step {
+        case .policyAgreement:
+            PolicyAgreementScreen(viewModel: viewModel)
+        case .nameSetup:
+            NameSetupScreen(viewModel: viewModel)
+        case .tagSetup:
+            TagSetupScreen(viewModel: viewModel)
+        case .tutorialChoice:
+            TutorialChoiceScreen(viewModel: viewModel)
+        case .tutorialTrackSearch:
+            TutorialTrackSearchScreen(
+                onSkip: viewModel.skipAllTutorialAndFinish,
+                onTrackSelected: { track in
+                    viewModel.selectTutorialTrack(track)
+                }
+            )
+        case .tutorialTrim:
+            TutorialTrimScreen(viewModel: viewModel)
+        case .tutorialHome:
+            TutorialHomeScreen(viewModel: viewModel)
+        case .tutorialDiaryDetail:
+            TutorialDiaryDetailScreen(viewModel: viewModel)
+        case .tutorialNotification:
+            TutorialNotificationScreen(viewModel: viewModel)
+        case .tutorialFinal:
+            TutorialFinalScreen(viewModel: viewModel)
+        }
+    }
+}
+
+private struct PolicyAgreementScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+    @State private var activeDocument: PolicyDocumentType?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let horizontalPadding = max(AppSpacing.m, geometry.size.width * 0.08)
+            let topPadding = geometry.safeAreaInsets.top + AppSpacing.l
+            let bottomPadding = geometry.safeAreaInsets.bottom + AppSpacing.l
+
+            ZStack {
+                LoginBackgroundVideoView()
+                    .ignoresSafeArea()
+
+                LinearGradient(
+                    colors: [Color.black.opacity(0.36), Color.black.opacity(0.9)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
+
+                    VStack(alignment: .leading, spacing: AppSpacing.m) {
+                        Text("짧게 들어도, 길게 남는 순간")
+                            .font(AppFont.paperlogy5Medium(size: 24))
+                            .foregroundStyle(.white)
+
+                        policyRow(
+                            title: "서비스 이용약관",
+                            isChecked: viewModel.isServiceTermsAgreed,
+                            onTap: {
+                                viewModel.isServiceTermsAgreed.toggle()
+                            },
+                            onSeeFullTextTap: {
+                                activeDocument = .serviceTerms
+                            }
+                        )
+
+                        policyRow(
+                            title: "개인정보 처리방침",
+                            isChecked: viewModel.isPrivacyAgreed,
+                            onTap: {
+                                viewModel.isPrivacyAgreed.toggle()
+                            },
+                            onSeeFullTextTap: {
+                                activeDocument = .privacy
+                            }
+                        )
+
+                        if let errorMessage = viewModel.errorMessage {
+                            Text(errorMessage)
+                                .font(AppFont.paperlogy4Regular(size: 13))
+                                .foregroundStyle(.red.opacity(0.95))
+                        }
+                    }
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, AppSpacing.xl)
+
+                    PrimaryButton(
+                        title: "전체 동의 후 시작하기",
+                        isLoading: viewModel.isLoading
+                    ) {
+                        Task {
+                            await viewModel.submitPolicyAgreement()
+                        }
+                    }
+                    .disabled(!viewModel.canSubmitPolicyAgreement || viewModel.isLoading)
+                    .opacity((viewModel.canSubmitPolicyAgreement && !viewModel.isLoading) ? 1 : 0.45)
+                    .padding(.horizontal, horizontalPadding)
+                    .padding(.bottom, bottomPadding)
+                }
+                .padding(.top, topPadding)
+            }
+        }
+        .sheet(item: $activeDocument) { documentType in
+            PolicyDocumentSheet(documentType: documentType)
+                .preferredColorScheme(.dark)
+        }
+    }
+
+    private func policyRow(
+        title: String,
+        isChecked: Bool,
+        onTap: @escaping () -> Void,
+        onSeeFullTextTap: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: AppSpacing.s) {
+            Button(action: onTap) {
+                Image(systemName: isChecked ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(isChecked ? AppColors.primary600 : .white.opacity(0.75))
+            }
+            .buttonStyle(.plain)
+
+            Text(title)
+                .font(AppFont.paperlogy4Regular(size: 15))
+                .foregroundStyle(.white.opacity(0.9))
+
+            Spacer(minLength: AppSpacing.s)
+
+            Button(action: onSeeFullTextTap) {
+                Text("전문확인")
+                    .font(AppFont.paperlogy4Regular(size: 14))
+                    .underline(true, color: AppColors.primary600.opacity(0.92))
+                    .foregroundStyle(AppColors.primary600.opacity(0.92))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+}
+
+private enum PolicyDocumentType: String, Identifiable {
+    case serviceTerms
+    case privacy
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .serviceTerms:
+            return "서비스 이용약관"
+        case .privacy:
+            return "개인정보 처리방침"
+        }
+    }
+
+    var fullText: String {
+        switch self {
+        case .serviceTerms:
+            return PolicyDocumentContent.serviceTerms
+        case .privacy:
+            return PolicyDocumentContent.privacyPolicy
+        }
+    }
+}
+
+private struct PolicyDocumentSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let documentType: PolicyDocumentType
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(documentType.fullText)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(AppSpacing.l)
+            }
+            .background(Color.black.ignoresSafeArea())
+            .navigationTitle(documentType.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("닫기") {
+                        dismiss()
+                    }
+                    .foregroundStyle(.white)
+                }
+            }
+        }
+    }
+}
+
+private struct NameSetupScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                Text("사용하실 이름이 무엇인가요?")
+                    .font(AppFont.paperlogy7Bold(size: 28))
+                    .foregroundStyle(.white)
+
+                Text("이름은 언제든지 바꿀 수 있습니다")
+                    .font(AppFont.paperlogy4Regular(size: 14))
+                    .foregroundStyle(.white.opacity(0.72))
+
+                Text("*이름은 1~20자, 영어/한글/숫자/공백만 사용 가능")
+                    .font(AppFont.paperlogy4Regular(size: 12))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .padding(.top, AppSpacing.xs)
+
+                TextField("이름 입력", text: $viewModel.nameDraft)
+                    .font(AppFont.paperlogy5Medium(size: 16))
+                    .foregroundStyle(.white)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding(.horizontal, AppSpacing.m)
+                    .padding(.vertical, AppSpacing.m)
+                    .background(Color.white.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                    }
+
+                if let validation = viewModel.validateName(viewModel.nameDraft), !viewModel.nameDraft.isEmpty {
+                    Text(validation)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(.red.opacity(0.95))
+                } else if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(.red.opacity(0.95))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.top, AppSpacing.xl)
+
+            Spacer(minLength: 0)
+
+            PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
+                Task {
+                    await viewModel.submitName()
+                }
+            }
+            .disabled(!viewModel.canSubmitName || viewModel.isLoading)
+            .opacity((viewModel.canSubmitName && !viewModel.isLoading) ? 1 : 0.45)
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.bottom, AppSpacing.xl)
+        }
+        .background(
+            LinearGradient(
+                colors: [Color.black, Color(hex: "#10131B")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+    }
+}
+
+private struct TagSetupScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                Text("개성을 나타내는 태그를 정해주세요")
+                    .font(AppFont.paperlogy7Bold(size: 28))
+                    .foregroundStyle(.white)
+
+                Text("언제든지 바꿀 수 있습니다")
+                    .font(AppFont.paperlogy4Regular(size: 14))
+                    .foregroundStyle(.white.opacity(0.72))
+
+                Text("*영문 소문자, 숫자, '_', '.' / 4~30자")
+                    .font(AppFont.paperlogy4Regular(size: 12))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .padding(.top, AppSpacing.xs)
+
+                HStack(spacing: AppSpacing.xs) {
+                    Text("@")
+                        .font(AppFont.paperlogy5Medium(size: 18))
+                        .foregroundStyle(.white.opacity(0.7))
+                    TextField("태그 입력", text: $viewModel.tagDraft)
+                        .font(AppFont.paperlogy5Medium(size: 16))
+                        .foregroundStyle(.white)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                .padding(.horizontal, AppSpacing.m)
+                .padding(.vertical, AppSpacing.m)
+                .background(Color.white.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                }
+
+                if let validation = viewModel.validateTag(viewModel.tagDraft), !viewModel.tagDraft.isEmpty {
+                    Text(validation)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(.red.opacity(0.95))
+                } else if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(AppFont.paperlogy4Regular(size: 13))
+                        .foregroundStyle(.red.opacity(0.95))
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.top, AppSpacing.xl)
+
+            Spacer(minLength: 0)
+
+            PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
+                Task {
+                    await viewModel.submitTag()
+                }
+            }
+            .disabled(!viewModel.canSubmitTag || viewModel.isLoading)
+            .opacity((viewModel.canSubmitTag && !viewModel.isLoading) ? 1 : 0.45)
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.bottom, AppSpacing.xl)
+        }
+        .background(
+            LinearGradient(
+                colors: [Color.black, Color(hex: "#10131B")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+    }
+}
+
+private struct TutorialChoiceScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            Text("첫번째 킬링파트를 추가해볼까요?")
+                .font(AppFont.paperlogy7Bold(size: 30))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, AppSpacing.xl)
+
+            Spacer(minLength: 0)
+
+            VStack(spacing: AppSpacing.s) {
+                PrimaryButton(title: "추가하기") {
+                    viewModel.startTutorialTrackSelection()
+                }
+                .padding(.horizontal, AppSpacing.l)
+
+                Button {
+                    viewModel.skipAllTutorialAndFinish()
+                } label: {
+                    Text("건너뛰기")
+                        .font(AppFont.paperlogy6SemiBold(size: 16))
+                        .foregroundStyle(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, AppSpacing.m)
+                        .background(Color.white.opacity(0.65))
+                        .clipShape(RoundedRectangle(cornerRadius: 24))
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, AppSpacing.l)
+            }
+            .padding(.bottom, AppSpacing.xl)
+        }
+        .background(
+            LinearGradient(
+                colors: [Color.black, Color(hex: "#141722")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+    }
+}
+
+private struct TutorialTrackSearchScreen: View {
+    @StateObject private var searchViewModel = AddTabViewModel()
+    @State private var dismissKeyboardSignal = 0
+
+    let onSkip: () -> Void
+    let onTrackSelected: (SpotifySimpleTrack) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            let listBottomInset = max(geometry.safeAreaInsets.bottom, AppSpacing.m) + AppSpacing.xl
+
+            ZStack(alignment: .top) {
+                LinearGradient(
+                    colors: [Color.black, Color(hex: "#1A1D27")],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .ignoresSafeArea()
+
+                VStack(spacing: AppSpacing.m) {
+                    HStack {
+                        Spacer()
+                        Button("건너뛰기") {
+                            onSkip()
+                        }
+                        .font(AppFont.paperlogy5Medium(size: 15))
+                        .foregroundStyle(.white.opacity(0.92))
+                    }
+                    .padding(.top, geometry.safeAreaInsets.top + AppSpacing.s)
+
+                    VStack(spacing: 4) {
+                        Text("어떤 곡으로 시작할까요?")
+                            .font(AppFont.paperlogy8ExtraBold(size: 34))
+                            .foregroundStyle(.white)
+                        Text("킬링파트 제작하기")
+                            .font(AppFont.paperlogy4Regular(size: 15))
+                            .foregroundStyle(.white.opacity(0.68))
+                    }
+                    .padding(.bottom, AppSpacing.s)
+
+                    AddSearchFieldView(
+                        query: $searchViewModel.query,
+                        hasQuery: searchViewModel.hasQuery,
+                        dismissKeyboardSignal: dismissKeyboardSignal,
+                        onSubmit: searchViewModel.submitSearch,
+                        onQueryChanged: searchViewModel.handleQueryChanged,
+                        onClear: searchViewModel.clearSearch
+                    )
+
+                    tutorialTrackContent(bottomInset: listBottomInset)
+                        .contentShape(Rectangle())
+                        .simultaneousGesture(
+                            TapGesture()
+                                .onEnded { dismissKeyboardSignal += 1 }
+                        )
+                }
+                .padding(.horizontal, AppSpacing.l)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tutorialTrackContent(bottomInset: CGFloat) -> some View {
+        if searchViewModel.isLoading {
+            VStack {
+                Spacer(minLength: 0)
+                ProgressView()
+                    .tint(AppColors.primary600)
+                Spacer(minLength: 0)
+            }
+        } else if let error = searchViewModel.errorMessage {
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                Text(error)
+                    .font(AppFont.paperlogy4Regular(size: 14))
+                    .foregroundStyle(.white.opacity(0.85))
+
+                Button("다시 시도") {
+                    searchViewModel.retrySearch()
+                }
+                .buttonStyle(.plain)
+                .font(AppFont.paperlogy6SemiBold(size: 13))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .foregroundStyle(.black)
+                .background(AppColors.primary600)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(AppSpacing.m)
+            .background(Color.white.opacity(0.06))
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+        } else if searchViewModel.shouldShowEmptyState {
+            VStack {
+                Spacer(minLength: 0)
+                Text("검색 결과가 없어요.")
+                    .font(AppFont.paperlogy5Medium(size: 15))
+                    .foregroundStyle(.white.opacity(0.8))
+                Spacer(minLength: 0)
+            }
+        } else {
+            ScrollView {
+                LazyVStack(spacing: AppSpacing.s) {
+                    ForEach(searchViewModel.tracks) { track in
+                        Button {
+                            onTrackSelected(track)
+                        } label: {
+                            TutorialTrackRow(track: track)
+                        }
+                        .buttonStyle(.plain)
+                        .onAppear {
+                            searchViewModel.loadMoreIfNeeded(currentTrackID: track.id)
+                        }
+                    }
+
+                    if searchViewModel.isLoadingMore {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .tint(.white.opacity(0.85))
+                            Spacer()
+                        }
+                        .padding(.top, AppSpacing.s)
+                    }
+                }
+                .padding(.bottom, max(bottomInset, AppSpacing.l))
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+private struct TutorialTrackRow: View {
+    let track: SpotifySimpleTrack
+
+    var body: some View {
+        HStack(spacing: AppSpacing.s) {
+            Group {
+                if let artworkURL = track.albumImageURL {
+                    AsyncImage(url: artworkURL) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image.resizable().scaledToFill()
+                        case .empty, .failure:
+                            placeholder
+                        @unknown default:
+                            placeholder
+                        }
+                    }
+                } else {
+                    placeholder
+                }
+            }
+            .frame(width: 56, height: 56)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(track.title)
+                    .font(AppFont.paperlogy6SemiBold(size: 15))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+
+                Text(track.artist)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(.white.opacity(0.72))
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(AppSpacing.s)
+        .background(Color.black.opacity(0.65))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay {
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        }
+    }
+
+    private var placeholder: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.12))
+            .overlay {
+                Image(systemName: "music.note")
+                    .foregroundStyle(.white.opacity(0.72))
+            }
+    }
+}
+
+private struct TutorialTrimScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        Group {
+            if let track = viewModel.selectedTrack {
+                NavigationStack {
+                    AddSearchDetailView(
+                        track: track,
+                        shouldNavigateToPlayKillingPartOnSave: false,
+                        skipButtonTitle: "건너뛰기",
+                        onSkip: viewModel.skipAllTutorialAndFinish,
+                        isTutorialTrimFocusEnabled: true,
+                        onSaveCompletedAfterDismiss: {
+                            Task {
+                                await viewModel.moveToTutorialHomeAfterDiarySaved()
+                            }
+                        }
+                    )
+                }
+            } else {
+                VStack(spacing: AppSpacing.s) {
+                    Text("선택한 곡 정보가 없어요.")
+                        .font(AppFont.paperlogy5Medium(size: 16))
+                        .foregroundStyle(.white.opacity(0.82))
+                    Button("곡 다시 선택") {
+                        viewModel.startTutorialTrackSelection()
+                    }
+                    .buttonStyle(.plain)
+                    .font(AppFont.paperlogy6SemiBold(size: 14))
+                    .foregroundStyle(AppColors.primary600)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.black.ignoresSafeArea())
+            }
+        }
+    }
+}
+
+private struct TutorialHomeScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+    @State private var selectedTab: TutorialHomeTab = .collection
+    @State private var tabTransitionDirection: Edge = .trailing
+    @State private var displayedMonth: Date = TutorialHomeScreen.startOfMonth(for: Date())
+    @State private var selectedDate: Date = Date()
+
+    private static var hasConfiguredSegmentedControlAppearance = false
+
+    var body: some View {
+        VStack(spacing: AppSpacing.m) {
+            header
+
+            topToggleTabs
+
+            ZStack {
+                if selectedTab == .collection {
+                    collectionContent
+                        .transition(tabContentTransition)
+                } else {
+                    calendarContent
+                        .transition(tabContentTransition)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            .clipped()
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(AppFont.paperlogy4Regular(size: 13))
+                    .foregroundStyle(.red.opacity(0.95))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            PrimaryButton(title: "다음으로") {
+                viewModel.goToDiaryDetailTutorial()
+            }
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.l)
+        .padding(.bottom, AppSpacing.l)
+        .background(
+            Image("my_background")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+        )
+        .task {
+            await viewModel.loadTutorialHomeData()
+            syncInitialCalendarStateIfNeeded()
+        }
+        .onAppear {
+            configureSegmentedControlFontIfNeeded()
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            Text("추가한 킬링파트는\n여기서 다시 볼 수 있어요.")
+                .font(AppFont.paperlogy7Bold(size: 30))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: AppSpacing.s)
+
+            Button("건너뛰기") {
+                viewModel.skipAllTutorialAndFinish()
+            }
+            .buttonStyle(.plain)
+            .font(AppFont.paperlogy5Medium(size: 14))
+            .foregroundStyle(.white.opacity(0.9))
+        }
+    }
+
+    private var topToggleTabs: some View {
+        Picker("튜토리얼 홈 탭", selection: segmentedSelectionBinding) {
+            ForEach(TutorialHomeTab.allCases, id: \.self) { tab in
+                Text(tab.title)
+                    .font(AppFont.paperlogy4Regular(size: 11))
+                    .tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .controlSize(.large)
+        .scaleEffect(x: 1, y: 1.08, anchor: .center)
+        .padding(.bottom, AppSpacing.xs)
+    }
+
+    private var segmentedSelectionBinding: Binding<TutorialHomeTab> {
+        Binding(
+            get: { selectedTab },
+            set: { newTab in
+                selectTab(newTab)
+            }
+        )
+    }
+
+    private func selectTab(_ newTab: TutorialHomeTab) {
+        let previousIndex = selectedTab.order
+        let nextIndex = newTab.order
+        guard previousIndex != nextIndex else { return }
+        tabTransitionDirection = nextIndex > previousIndex ? .trailing : .leading
+
+        withAnimation(.interactiveSpring(response: 0.32, dampingFraction: 0.85, blendDuration: 0.1)) {
+            selectedTab = newTab
+        }
+    }
+
+    private var tabContentTransition: AnyTransition {
+        .asymmetric(
+            insertion: .move(edge: tabTransitionDirection).combined(with: .opacity),
+            removal: .move(edge: tabTransitionDirection == .trailing ? .leading : .trailing).combined(with: .opacity)
+        )
+    }
+
+    @ViewBuilder
+    private var collectionContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.m) {
+                MyCollectionProfileCard(
+                    displayName: viewModel.displayName,
+                    displayTag: viewModel.displayTag,
+                    profileImageURL: profileImageURL,
+                    killingPartStatText: "\(viewModel.tutorialDiaries.count)",
+                    fanStatText: "0",
+                    pickStatText: "0",
+                    onFanStatTap: {},
+                    onPickStatTap: {},
+                    onEditProfileTap: {}
+                )
+                .background(Color.black.opacity(0.74))
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                }
+
+                Text("내 킬링파트")
+                    .font(AppFont.paperlogy6SemiBold(size: 14))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, AppSpacing.xs)
+
+                if viewModel.tutorialDiaries.isEmpty {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color.white.opacity(0.08))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 140)
+                        .overlay {
+                            if viewModel.isLoading {
+                                ProgressView()
+                                    .tint(AppColors.primary600)
+                            } else {
+                                Text("아직 작성한 피드가 없어요.")
+                                    .font(AppFont.paperlogy5Medium(size: 14))
+                                    .foregroundStyle(.white.opacity(0.72))
+                            }
+                        }
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                        }
+                } else {
+                    LazyVGrid(columns: feedGridColumns, spacing: AppSpacing.s) {
+                        ForEach(viewModel.tutorialDiaries.prefix(6)) { diary in
+                            MyCollectionFeedCard(
+                                feed: diary,
+                                formattedUpdateDate: formattedUpdateDate(from: diary.updateDate)
+                            )
+                            .background(Color.black.opacity(0.78))
+                            .clipShape(RoundedRectangle(cornerRadius: 16))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.bottom, AppSpacing.m)
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private var calendarContent: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.m) {
+            MusicCalendarHeaderSection(
+                yearText: "\(year(from: displayedMonth))년",
+                monthText: "\(month(from: displayedMonth))월",
+                onMonthTap: {},
+                onPreviousMonthTap: {
+                    guard let movedMonth = Calendar.current.date(byAdding: .month, value: -1, to: displayedMonth) else { return }
+                    displayedMonth = Self.startOfMonth(for: movedMonth)
+                    selectedDate = displayedMonth
+                },
+                onNextMonthTap: {
+                    guard let movedMonth = Calendar.current.date(byAdding: .month, value: 1, to: displayedMonth) else { return }
+                    displayedMonth = Self.startOfMonth(for: movedMonth)
+                    selectedDate = displayedMonth
+                }
+            )
+
+            MusicCalendarCalendarSection(
+                weekdayTitles: ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"],
+                dayCells: calendarDayCells,
+                onDayTap: { date in
+                    withAnimation(.easeInOut(duration: 0.24)) {
+                        selectedDate = date
+                    }
+                }
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            }
+
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                Text(selectedDateTitle)
+                    .font(AppFont.paperlogy6SemiBold(size: 16))
+                    .foregroundStyle(.white)
+
+                if diariesForSelectedDate.isEmpty {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color.white.opacity(0.06))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 74)
+                        .overlay {
+                            Text("선택한 날짜의 킬링파트가 없어요.")
+                                .font(AppFont.paperlogy4Regular(size: 13))
+                                .foregroundStyle(.white.opacity(0.72))
+                        }
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                        }
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: AppSpacing.xs) {
+                            ForEach(diariesForSelectedDate.prefix(4)) { diary in
+                                MusicCalendarDiaryRow(diary: diary)
+                                    .background(Color.black.opacity(0.62))
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                                    }
+                            }
+                        }
+                        .padding(.bottom, AppSpacing.xs)
+                    }
+                    .scrollIndicators(.hidden)
+                }
+            }
+        }
+    }
+
+    private var profileImageURL: URL? {
+        guard
+            let raw = viewModel.tutorialDiaries.first?.profileImageUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else {
+            return nil
+        }
+        if let parsed = URL(string: raw), parsed.scheme != nil {
+            return parsed
+        }
+        if raw.hasPrefix("//"), let parsed = URL(string: "https:\(raw)") {
+            return parsed
+        }
+        return URL(string: "https://\(raw)")
+    }
+
+    private var feedGridColumns: [GridItem] {
+        [
+            GridItem(.flexible(minimum: 0, maximum: .infinity), spacing: AppSpacing.s),
+            GridItem(.flexible(minimum: 0, maximum: .infinity), spacing: AppSpacing.s)
+        ]
+    }
+
+    private var diariesForSelectedDate: [DiaryFeedModel] {
+        viewModel.calendarDiariesByDate[Self.dateKeyFormatter.string(from: selectedDate)] ?? []
+    }
+
+    private var selectedDateTitle: String {
+        Self.selectedDateFormatter.string(from: selectedDate)
+    }
+
+    private var calendarDayCells: [MusicCalendarDayCell] {
+        let calendar = Calendar.current
+        let firstDayOfMonth = Self.startOfMonth(for: displayedMonth)
+        let numberOfDaysInMonth = calendar.range(of: .day, in: .month, for: firstDayOfMonth)?.count ?? 0
+        let firstWeekdayIndex = max(calendar.component(.weekday, from: firstDayOfMonth) - 1, 0)
+
+        var cells: [MusicCalendarDayCell] = []
+        cells.reserveCapacity(firstWeekdayIndex + numberOfDaysInMonth + 7)
+
+        if firstWeekdayIndex > 0 {
+            for _ in 0..<firstWeekdayIndex {
+                cells.append(.placeholder)
+            }
+        }
+
+        if numberOfDaysInMonth > 0 {
+            for day in 1...numberOfDaysInMonth {
+                guard let date = calendar.date(byAdding: .day, value: day - 1, to: firstDayOfMonth) else { continue }
+                let key = Self.dateKeyFormatter.string(from: date)
+                let hasDiary = (viewModel.calendarDiariesByDate[key]?.isEmpty == false)
+                    || ((viewModel.calendarDiaryCountByDate.first { $0.0 == key }?.1 ?? 0) > 0)
+                cells.append(
+                    MusicCalendarDayCell(
+                        date: date,
+                        dayNumber: day,
+                        weekday: calendar.component(.weekday, from: date),
+                        isToday: calendar.isDateInToday(date),
+                        isSelected: calendar.isDate(date, inSameDayAs: selectedDate),
+                        hasDiary: hasDiary
+                    )
+                )
+            }
+        }
+
+        let trailingPlaceholderCount = (7 - (cells.count % 7)) % 7
+        if trailingPlaceholderCount > 0 {
+            for _ in 0..<trailingPlaceholderCount {
+                cells.append(.placeholder)
+            }
+        }
+
+        if cells.count < 42 {
+            for _ in 0..<(42 - cells.count) {
+                cells.append(.placeholder)
+            }
+        }
+
+        return cells
+    }
+
+    private func syncInitialCalendarStateIfNeeded() {
+        let entries = viewModel.calendarDiaryCountByDate.compactMap { entry -> Date? in
+            guard entry.1 > 0 else { return nil }
+            return Self.dateKeyFormatter.date(from: entry.0)
+        }
+        if let firstDiaryDate = entries.sorted().first {
+            displayedMonth = Self.startOfMonth(for: firstDiaryDate)
+            selectedDate = firstDiaryDate
+        } else {
+            displayedMonth = Self.startOfMonth(for: Date())
+            selectedDate = Date()
+        }
+    }
+
+    private func formattedUpdateDate(from rawUpdateDate: String) -> String {
+        let datePart = rawUpdateDate.split(separator: "T").first.map(String.init) ?? rawUpdateDate
+        return datePart.replacingOccurrences(of: "-", with: ".")
+    }
+
+    private func year(from date: Date) -> Int {
+        Calendar.current.component(.year, from: date)
+    }
+
+    private func month(from date: Date) -> Int {
+        Calendar.current.component(.month, from: date)
+    }
+
+    private static func startOfMonth(for date: Date) -> Date {
+        Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: date)) ?? date
+    }
+
+    private func configureSegmentedControlFontIfNeeded() {
+        guard !Self.hasConfiguredSegmentedControlAppearance else { return }
+        Self.hasConfiguredSegmentedControlAppearance = true
+
+        let fallbackFont = UIFont.systemFont(ofSize: 13, weight: .regular)
+        let segmentFont = UIFont(name: "Paperlogy-4Regular", size: 13) ?? fallbackFont
+
+        UISegmentedControl.appearance().setTitleTextAttributes([.font: segmentFont], for: .normal)
+        UISegmentedControl.appearance().setTitleTextAttributes([.font: segmentFont], for: .selected)
+    }
+
+    private static let dateKeyFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = .current
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let selectedDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = .current
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.timeZone = .current
+        formatter.dateFormat = "M월 d일 EEEE"
+        return formatter
+    }()
+}
+
+private enum TutorialHomeTab: CaseIterable {
+    case collection
+    case calendar
+
+    var title: String {
+        switch self {
+        case .collection:
+            return "내 컬렉션"
+        case .calendar:
+            return "뮤직캘린더"
+        }
+    }
+
+    var order: Int {
+        switch self {
+        case .collection:
+            return 0
+        case .calendar:
+            return 1
+        }
+    }
+}
+
+private struct TutorialDiaryDetailScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    private let mockDiary = DiaryFeedModel(
+        diaryId: 999_001,
+        artist: "Davinci Leo",
+        musicTitle: "Death Sonnet von Dat",
+        albumImageUrl: "https://i.imgur.com/8T0h6Zx.png",
+        content: "오늘 하루는 유난히 공허하게 흘러간 것 같다. 해야 할 일은 분명 있었지만 마음은 잘 따라주지 않았고, 생각들은 제자리를 맴돌았다. 그러다 문득, 특별한 이유 없이 음악을 들어야겠다는 충동이 찾아왔다.",
+        videoUrl: "https://www.youtube.com/embed/J---aiyznGQ?playsinline=1",
+        scope: .public,
+        duration: "00:30",
+        totalDuration: "03:24",
+        start: "00:20",
+        end: "00:50",
+        createDate: "2026-05-01T00:00:00",
+        updateDate: "2026-05-01T00:00:00",
+        isLiked: true,
+        isStored: false,
+        likeCount: 26,
+        userId: 9_999,
+        username: "킬링파트",
+        tag: "KILLINGPART",
+        profileImageUrl: nil
+    )
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            NavigationStack {
+                SocialMyCollectionDiary(
+                    diaryId: mockDiary.diaryId,
+                    displayTag: "@KILLINGPART",
+                    diary: mockDiary
+                )
+            }
+
+            Button("건너뛰기") {
+                viewModel.skipAllTutorialAndFinish()
+            }
+            .buttonStyle(.plain)
+            .font(AppFont.paperlogy5Medium(size: 14))
+            .foregroundStyle(.white.opacity(0.9))
+            .padding(.top, AppSpacing.l)
+            .padding(.trailing, AppSpacing.l)
+        }
+        .safeAreaInset(edge: .bottom) {
+            PrimaryButton(title: "다음으로") {
+                viewModel.goToNotificationTutorial()
+            }
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.top, AppSpacing.s)
+            .padding(.bottom, AppSpacing.s)
+            .background(Color.black.opacity(0.92))
+        }
+    }
+}
+
+private struct TutorialNotificationScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    private let mockNotifications: [(String, String)] = [
+        ("[공지] 신규 업데이트 3.1 예정입니다!", ""),
+        ("OOO님이 회원님을 픽했어요", "04.15"),
+        ("OOO의 새로운 업데이트가 배포되었어요", "04.16"),
+        ("OOO님이 최근 활동을 공유했어요", "04.16"),
+        ("OOO의 이벤트에 초대받았어요", "04.17"),
+        ("OOO님과의 대화가 시작되었어요", "04.17")
+    ]
+
+    var body: some View {
+        VStack(spacing: AppSpacing.m) {
+            HStack {
+                Spacer(minLength: 0)
+                Button("건너뛰기") {
+                    viewModel.skipAllTutorialAndFinish()
+                }
+            }
+            .buttonStyle(.plain)
+            .font(AppFont.paperlogy5Medium(size: 14))
+            .foregroundStyle(.white.opacity(0.9))
+
+            Text("알림을 통해\n내 픽과 팬덤의 활동을 확인하세요!")
+                .font(AppFont.paperlogy7Bold(size: 30))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+
+            VStack(alignment: .leading, spacing: AppSpacing.s) {
+                HStack(spacing: AppSpacing.s) {
+                    Image(systemName: "bell")
+                        .font(.system(size: 22, weight: .semibold))
+                    Text("알림 목록")
+                        .font(AppFont.paperlogy7Bold(size: 24))
+                }
+                .foregroundStyle(AppColors.primary600)
+
+                ForEach(Array(mockNotifications.enumerated()), id: \.offset) { index, row in
+                    if index == 0 {
+                        Text(row.0)
+                            .font(AppFont.paperlogy6SemiBold(size: 17))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, AppSpacing.m)
+                            .padding(.vertical, AppSpacing.m)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(AppColors.primary600)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                    } else {
+                        HStack {
+                            Text(row.0)
+                                .font(AppFont.paperlogy4Regular(size: 15))
+                                .foregroundStyle(.white.opacity(0.85))
+                            Spacer(minLength: AppSpacing.s)
+                            Text(row.1)
+                                .font(AppFont.paperlogy4Regular(size: 14))
+                                .foregroundStyle(.white.opacity(0.7))
+                        }
+                        .padding(.vertical, AppSpacing.xs)
+                    }
+                }
+            }
+            .padding(AppSpacing.m)
+            .background(Color.black.opacity(0.72))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            }
+
+            Spacer(minLength: 0)
+
+            PrimaryButton(title: "다음으로") {
+                viewModel.goToFinalTutorial()
+            }
+        }
+        .padding(.horizontal, AppSpacing.l)
+        .padding(.top, AppSpacing.l)
+        .padding(.bottom, AppSpacing.l)
+        .background(
+            LinearGradient(
+                colors: [Color.black, Color(hex: "#171A24")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+    }
+}
+
+private struct TutorialFinalScreen: View {
+    @ObservedObject var viewModel: InitialSetupFlowViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+
+            Text("이제 킬링파트를\n시작해보세요.")
+                .font(AppFont.paperlogy7Bold(size: 38))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+
+            Spacer(minLength: 0)
+
+            PrimaryButton(title: "시작하기") {
+                viewModel.finishTutorial()
+            }
+            .padding(.horizontal, AppSpacing.l)
+            .padding(.bottom, AppSpacing.xl)
+        }
+        .background(
+            LinearGradient(
+                colors: [Color.black, Color(hex: "#171A24")],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+        )
+    }
+}
+
+private enum PolicyDocumentContent {
+    static let privacyPolicy = """
+개인정보 처리방침
+
+제1조(목적)
+킬링파트(이하 ‘회사'라고 함)는 회사가 제공하고자 하는 서비스(이하 ‘회사 서비스’)를 이용하는 개인(이하 ‘이용자’ 또는 ‘개인’)의 정보(이하 ‘개인정보’)를 보호하기 위해, 개인정보보호법, 정보통신망 이용촉진 및 정보보호 등에 관한 법률(이하 '정보통신망법') 등 관련 법령을 준수하고, 서비스 이용자의 개인정보 보호 관련한 고충을 신속하고 원활하게 처리할 수 있도록 하기 위하여 다음과 같이 개인정보처리방침(이하 ‘본 방침’)을 수립합니다.
+
+제2조(개인정보 처리의 원칙)
+개인정보 관련 법령 및 본 방침에 따라 회사는 이용자의 개인정보를 수집할 수 있으며 수집된 개인정보는 개인의 동의가 있는 경우에 한해 제3자에게 제공될 수 있습니다. 단, 법령의 규정 등에 의해 적법하게 강제되는 경우 회사는 수집한 이용자의 개인정보를 사전에 개인의 동의 없이 제3자에게 제공할 수도 있습니다.
+
+제3조(본 방침의 공개)
+
+1. 회사는 이용자가 언제든지 쉽게 본 방침을 확인할 수 있도록 회사 홈페이지 첫 화면 또는 첫 화면과의 연결화면을 통해 본 방침을 공개하고 있습니다.
+
+2. 회사는 제1항에 따라 본 방침을 공개하는 경우 글자 크기, 색상 등을 활용하여 이용자가 본 방침을 쉽게 확인할 수 있도록 합니다.
+
+제4조(본 방침의 변경)
+
+1. 본 방침은 개인정보 관련 법령, 지침, 고시 또는 정부나 회사 서비스의 정책이나 내용의 변경에 따라 개정될 수 있습니다.
+
+2. 회사는 제1항에 따라 본 방침을 개정하는 경우 다음 각 호 하나 이상의 방법으로 공지합니다.
+
+가. 회사가 운영하는 인터넷 홈페이지의 첫 화면의 공지사항란 또는 별도의 창을 통하여 공지하는 방법
+
+나. 서면·모사전송·전자우편 또는 이와 비슷한 방법으로 이용자에게 공지하는 방법
+
+3. 회사는 제2항의 공지는 본 방침 개정의 시행일로부터 최소 7일 이전에 공지합니다. 다만, 이용자 권리의 중요한 변경이 있을 경우에는 최소 30일 전에 공지합니다.
+
+제5조(회원 가입을 위한 정보)
+회사는 이용자의 회사 서비스에 대한 회원가입을 위하여 다음과 같은 정보를 수집합니다.
+
+1. 필수 수집 정보: 이메일 주소, 이름 및 닉네임
+
+2. 선택 수집 정보: 프로필 사진
+
+제6조(회사 서비스 제공을 위한 정보)
+회사는 이용자에게 회사의 서비스를 제공하기 위하여 다음과 같은 정보를 수집합니다.
+
+1. 필수 수집 정보: 아이디, 이메일 주소 및 이름
+
+제7조(서비스 이용 및 부정 이용 확인을 위한 정보)
+
+회사는 이용자의 서비스 이용에 따른 통계∙분석 및 부정이용의 확인∙분석을 위하여 다음과 같은 정보를 수집합니다. (부정이용이란 회원탈퇴 후 재가입, 상품구매 후 구매취소 등을 반복적으로 행하는 등 회사가 제공하는 할인쿠폰, 이벤트 혜택 등의 경제상 이익을 불·편법적으로 수취하는 행위, 이용약관 등에서 금지하고 있는 행위, 명의도용 등의 불·편법행위 등을 말합니다.)
+
+1. 필수 수집 정보: 서비스 이용기록
+
+제8조(개인정보 수집 방법)
+
+회사는 다음과 같은 방법으로 이용자의 개인정보를 수집합니다.
+
+1. 이용자가 회사의 홈페이지에 자신의 개인정보를 입력하는 방식
+
+2. 어플리케이션 등 회사가 제공하는 홈페이지 외의 서비스를 통해 이용자가 자신의 개인정보를 입력하는 방식
+
+제9조(개인정보의 이용)
+
+회사는 개인정보를 다음 각 호의 경우에 이용합니다.
+
+1. 공지사항의 전달 등 회사운영에 필요한 경우
+
+2. 이용문의에 대한 회신, 불만의 처리 등 이용자에 대한 서비스 개선을 위한 경우
+
+3. 회사의 서비스를 제공하기 위한 경우
+
+4. 법령 및 회사 약관을 위반하는 회원에 대한 이용 제한 조치, 부정 이용 행위를 포함하여 서비스의 원활한 운영에 지장을 주는 행위에 대한 방지 및 제재를 위한 경우
+
+5. 신규 서비스 개발을 위한 경우
+
+6. 인구통계학적 분석, 서비스 방문 및 이용기록의 분석을 위한 경우
+
+7. 개인정보 및 관심에 기반한 이용자간 관계의 형성을 위한 경우
+
+제10조(개인정보의 보유 및 이용기간)
+1. 회사는 이용자의 개인정보에 대해 개인정보의 수집·이용 목적 달성을 위한 기간 동안 개인정보를 보유 및 이용합니다.
+
+2. 전항에도 불구하고 회사는 내부 방침에 의해 서비스 부정이용기록은 부정 가입 및 이용 방지를 위하여 회원 탈퇴 시점으로부터 최대 1년간 보관합니다.
+
+제11조(법령에 따른 개인정보의 보유 및 이용기간)
+
+회사는 관계법령에 따라 다음과 같이 개인정보를 보유 및 이용합니다.
+
+1. 전자상거래 등에서의 소비자보호에 관한 법률에 따른 보유정보 및 보유기간
+
+가. 계약 또는 청약철회 등에 관한 기록 : 5년
+
+나. 대금결제 및 재화 등의 공급에 관한 기록 : 5년
+
+다. 소비자의 불만 또는 분쟁처리에 관한 기록 : 3년
+
+라. 표시•광고에 관한 기록 : 6개월
+
+2. 통신비밀보호법에 따른 보유정보 및 보유기간
+
+가. 웹사이트 로그 기록 자료 : 3개월
+
+3. 전자금융거래법에 따른 보유정보 및 보유기간
+
+가. 전자금융거래에 관한 기록 : 5년4. 위치정보의 보호 및 이용 등에 관한 법률
+
+가. 개인위치정보에 관한 기록 : 6개월
+
+제12조(개인정보의 파기원칙)
+회사는 원칙적으로 이용자의 개인정보 처리 목적의 달성, 보유·이용기간의 경과 등 개인정보가 필요하지 않을 경우에는 해당 정보를 지체 없이 파기합니다.
+
+제13조(개인정보파기절차)
+
+1. 이용자가 회원가입 등을 위해 입력한 정보는 개인정보 처리 목적이 달성된 후 별도의 DB로 옮겨져(종이의 경우 별도의 서류함)
+
+내부 방침 및 기타 관련 법령에 의한 정보보호 사유에 따라(보유 및 이용기간 참조) 일정 기간 저장된 후 파기 되어집니다.
+
+2. 회사는 파기 사유가 발생한 개인정보를 개인정보보호 책임자의 승인절차를 거쳐 파기합니다.
+
+제14조(개인정보파기방법)
+
+회사는 전자적 파일형태로 저장된 개인정보는 기록을 재생할 수 없는 기술적 방법을 사용하여 삭제하며, 종이로 출력된 개인정보는
+
+분쇄기로 분쇄하거나 소각 등을 통하여 파기합니다.
+
+제15조(광고성 정보의 전송 조치)
+
+1. 회사는 전자적 전송매체를 이용하여 영리목적의 광고성 정보를 전송하는 경우 이용자의 명시적인 사전동의를 받습니다. 다만, 다음 각호 어느 하나에 해당하는 경우에는 사전 동의를 받지 않습니다
+
+가. 회사가 재화 등의 거래관계를 통하여 수신자로부터 직접 연락처를 수집한 경우, 거래가 종료된 날로부터 6개월
+
+이내에 회사가 처리하고 수신자와 거래한 것과 동종의 재화 등에 대한 영리목적의 광고성 정보를 전송하려는 경우
+
+나. 「방문판매 등에 관한 법률」에 따른 전화권유판매자가 육성으로 수신자에게 개인정보의 수집출처를 고지하고 전화권유를 하는 경우
+
+2. 회사는 전항에도 불구하고 수신자가 수신거부의사를 표시하거나 사전 동의를 철회한 경우에는 영리목적의 광고성 정보를 전송하지 않으며 수신거부 및 수신동의 철회에 대한 처리 결과를 알립니다.
+
+3. 회사는 오후 9시부터 그다음 날 오전 8시까지의 시간에 전자적 전송매체를 이용하여 영리목적의 광고성 정보를 전송하는 경우에는 제1항에도 불구하고 그 수신자로부터 별도의 사전 동의를 받습니다.
+
+4. 회사는 전자적 전송매체를 이용하여 영리목적의 광고성 정보를 전송하는 경우 다음의 사항 등을 광고성 정보에 구체적으로 밝힙니다.
+
+가. 회사명 및 연락처
+
+나. 수신 거부 또는 수신 동의의 철회 의사표시에 관한 사항의 표시
+
+5. 회사는 전자적 전송매체를 이용하여 영리목적의 광고성 정보를 전송하는 경우 다음 각 호의 어느 하나에 해당하는 조치를 하지 않습니다.
+
+가. 광고성 정보 수신자의 수신거부 또는 수신동의의 철회를 회피·방해하는 조치
+
+나. 숫자·부호 또는 문자를 조합하여 전화번호·전자우편주소 등 수신자의 연락처를 자동으로 만들어 내는 조치
+
+다. 영리목적의 광고성 정보를 전송할 목적으로 전화번호 또는 전자우편주소를 자동으로 등록하는 조치
+
+라. 광고성 정보 전송자의 신원이나 광고 전송 출처를 감추기 위한 각종 조치
+
+마. 영리목적의 광고성 정보를 전송할 목적으로 수신자를 기망하여 회신을 유도하는 각종 조치
+
+제16조(아동의 개인정보보호)
+
+1. 회사는 만 14세 미만 아동의 개인정보 보호를 위하여 만 14세 이상의 이용자에 한하여 회원가입을 허용합니다.
+
+2. 제1항에도 불구하고 회사는 이용자가 만 14세 미만의 아동일 경우에는, 그 아동의 법정대리인으로부터 그 아동의 개인정보 수집, 이용, 제공 등의 동의를 그 아동의 법정대리인으로부터 받습니다.
+
+3. 제2항의 경우 회사는 그 법정대리인의 이름, 생년월일, 성별, 중복가입확인정보(ID), 휴대폰 번호 등을 추가로 수집합니다.
+
+제17조(개인정보 조회 및 수집동의 철회)
+1. 이용자 및 법정 대리인은 언제든지 등록되어 있는 자신의 개인정보를 조회하거나 수정할 수 있으며 개인정보수집 동의 철회를 요청할 수 있습니다.
+
+2. 이용자 및 법정 대리인은 자신의 가입정보 수집 등에 대한 동의를 철회하기 위해서는 개인정보보호책임자 또는 담당자에게 서면, 전화 또는 전자우편주소로 연락하시면 회사는 지체 없이 조치하겠습니다.
+
+제18조(개인정보 정보변경 등)
+
+1. 이용자는 회사에게 전조의 방법을 통해 개인정보의 오류에 대한 정정을 요청할 수 있습니다.
+
+2. 회사는 전항의 경우에 개인정보의 정정을 완료하기 전까지 개인정보를 이용 또는 제공하지 않으며 잘못된 개인정보를 제3자에게 이미 제공한 경우에는 정정 처리결과를 제3자에게 지체 없이 통지하여 정정이 이루어지도록 하겠습니다.
+
+제19조(이용자의 의무)
+
+1. 이용자는 자신의 개인정보를 최신의 상태로 유지해야 하며, 이용자의 부정확한 정보 입력으로 발생하는 문제의 책임은 이용자 자신에게 있습니다.
+
+2. 타인의 개인정보를 도용한 회원가입의 경우 이용자 자격을 상실하거나 관련 개인정보보호 법령에 의해 처벌받을 수 있습니다.
+
+3. 이용자는 전자우편주소, 비밀번호 등에 대한 보안을 유지할 책임이 있으며 제3자에게 이를 양도하거나 대여할 수 없습니다.
+
+제20조(개인정보 유출 등에 대한 조치)
+
+회사는 개인정보의 분실·도난·유출(이하 "유출 등"이라 한다) 사실을 안 때에는 지체 없이 다음 각 호의 모든 사항을 해당 이용자에게 알리고 방송통신위원회 또는 한국인터넷진흥원에 신고합니다.
+
+1. 유출 등이 된 개인정보 항목
+
+2. 유출 등이 발생한 시점
+
+3. 이용자가 취할 수 있는 조치
+
+4. 정보통신서비스 제공자 등의 대응 조치
+
+5. 이용자가 상담 등을 접수할 수 있는 부서 및 연락처
+
+제21조(개인정보 유출 등에 대한 조치의 예외)
+
+회사는 전조에도 불구하고 이용자의 연락처를 알 수 없는 등 정당한 사유가 있는 경우에는 회사의 홈페이지에 30일 이상 게시하는
+
+방법으로 전조의 통지를 갈음하는 조치를 취할 수 있습니다.
+
+제22조(개인정보 자동 수집 장치의 설치·운영 및 거부에 관한 사항)1. 회사는 이용자에게 개별적인 맞춤서비스를 제공하기 위해 이용 정보를 저장하고 수시로 불러오는 개인정보 자동 수집장치(이하 '쿠키')를 사용합니다. 쿠키는 웹사이트를 운영하는데 이용되는 서버(http)가 이용자의 웹브라우저(PC 및 모바일을 포함)에게 보내는 소량의 정보이며 이용자의 저장공간에 저장되기도 합니다.
+
+2. 이용자는 쿠키 설치에 대한 선택권을 가지고 있습니다. 따라서 이용자는 웹브라우저에서 옵션을 설정함으로써 모든 쿠키를 허용하거나, 쿠키가 저장될 때마다 확인을 거치거나, 아니면 모든 쿠키의 저장을 거부할 수도 있습니다.
+
+3. 다만, 쿠키의 저장을 거부할 경우에는 로그인이 필요한 회사의 일부 서비스는 이용에 어려움이 있을 수 있습니다.
+
+제23조(쿠키 설치 허용 지정 방법)
+
+웹브라우저 옵션 설정을 통해 쿠키 허용, 쿠키 차단 등의 설정을 할 수 있습니다.
+
+1. Edge : 웹브라우저 우측 상단의 설정 메뉴 > 쿠키 및 사이트 권한 > 쿠키 및 사이트 데이터 관리 및 삭제
+
+2. Chrome : 웹브라우저 우측 상단의 설정 메뉴 > 개인정보 및 보안 > 쿠키 및 기타 사이트 데이터
+
+3. Whale : 웹브라우저 우측 상단의 설정 메뉴 > 개인정보 보호 > 쿠키 및 기타 사이트 데이터
+
+제24조(개인정보 보호 책임자)
+1. 회사는 이용자의 개인정보를 보호하고 개인정보와 관련한 불만을 처리하기 위하여 아래와 같이 관련 부서 및 개인정보 보호
+
+책임자를 지정하고 있습니다.
+
+가. 개인정보 보호 책임자
+
+1) 성명: 김기영
+
+2) 직책: PO
+
+3) 전화번호: 010-8831-8775
+
+4) 이메일: killingpartofficial@gmail.com
+
+제25조(권익침해에 대한 구제방법)
+
+1. 정보주체는 개인정보침해로 인한 구제를 받기 위하여 개인정보분쟁조정위원회, 한국인터넷진흥원 개인정보침해신고센터 등에
+
+분쟁해결이나 상담 등을 신청할 수 있습니다. 이 밖에 기타 개인정보침해의 신고, 상담에 대하여는 아래의 기관에 문의하시기
+
+바랍니다.
+
+가. 개인정보분쟁조정위원회 : (국번없이) 1833-6972 (www.kopico.go.kr)
+
+나. 개인정보침해신고센터 : (국번없이) 118 (privacy.kisa.or.kr)
+
+다. 대검찰청 : (국번없이) 1301 (www.spo.go.kr)
+
+라. 경찰청 : (국번없이) 182 (ecrm.cyber.go.kr)
+
+2. 회사는 정보주체의 개인정보자기결정권을 보장하고, 개인정보침해로 인한 상담 및 피해 구제를 위해 노력하고 있으며, 신고나
+
+상담이 필요한 경우 제1항의 담당부서로 연락해주시기 바랍니다.
+
+3. 개인정보 보호법 제35조(개인정보의 열람), 제36조(개인정보의 정정·삭제), 제37조(개인정보의 처리정지 등)의 규정에 의한
+
+요구에 대 하여 공공기관의 장이 행한 처분 또는 부작위로 인하여 권리 또는 이익의 침해를 받은 자는 행정심판법이 정하는
+
+바에 따라 행정심판을 청구할 수 있습니다.
+
+가. 중앙행정심판위원회 : (국번없이) 110 (www.simpan.go.kr)
+
+부칙
+제1조 본 방침은 2025.11.20.부터 시행됩니다.
+"""
+
+    static let serviceTerms = """
+서비스 이용 약관
+- 시행일자 : 2026.03.18
+    
+    서비스 공급자 : 킬링파트
+    
+    무료 서비스만 제공 중
+    
+    회원가입 승낙 및 제약조건 : 없음
+    
+    제공하는 서비스 내역 : 음악 콘텐츠의 특정 구간 기록 및 저장 기능 / 킬링파트 관련 게시물 작성, 편집, 공개, 공유 기능 / 다른 이용자가 작성한 킬링파트 및 관련 콘텐츠의 탐색, 조회 기능 / 모바일 애플리케이션 및 기타 전자적 방식으로 제공되는 관련 제반 서비스 → 별도 첨부 X
+    
+    광고성 정보 수신 여부 : 예 → 추후 영리 목적으로 광고성 정보 수신 여부 목적, 이용약관과 별개로 따로 받아야 함.
+    
+    게시물의 관리 및 지식 재산권 여부 : 예 (콘텐츠 작성 여부 / 당사가 이용자가 만든 컨텐츠를 자유롭게 사용 가능 → 2차적 저작물 또는 편집 저작물 작성, 서비스 개선 및 새로운 서비스 개발, 미디어, 통신사 등을 통한 홍보 목적)
+    
+    민사소송법에 따른 관할법원에 따름ㅅ
+    
+
+## 제1조(목적)
+
+이 약관은 킬링파트 (이하 '회사' 라고 합니다)가 제공하는 제반 서비스의 이용과 관련하여 회사와 회원과의
+권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 합니다.
+
+## 제2조(정의)
+
+이 약관에서 사용하는 주요 용어의 정의는 다음과 같습니다.
+
+1. '서비스'라 함은 구현되는 단말기(PC, TV, 휴대형단말기 등의 각종 유무선 장치를 포함)와 상관없이 '이용자'가 이용할 수 있는 회사가 제공하는 제반 서비스를 의미합니다.
+2. '이용자'란 이 약관에 따라 회사가 제공하는 서비스를 받는 '개인회원', '기업회원' 및 '비회원'을 말합니다.
+3. '개인회원'은 회사에 개인정보를 제공하여 회원등록을 한 사람으로, 회사로부터 지속적으로 정보를 제공받고 '회사'가 제공하는 서비스를 계속적으로 이용할 수 있는 자를 말합니다.
+4. '기업회원'은 회사에 기업정보 및 개인정보를 제공하여 회원등록을 한 사람으로, 회사로부터 지속적으로 정보를 제공받고 회사가 제공하는 서비스를 계속적으로 이용할 수 있는 자를 말합니다.
+5. '비회원'은 회원가입 없이 회사가 제공하는 서비스를 이용하는 자를 말합니다.
+6. '아이디(ID)'라 함은 회원의 식별과 서비스이용을 위하여 회원이 정하고 회사가 승인하는 문자 또는 문자와 숫자의 조합을 의미합니다.
+7. '비밀번호'라 함은 회원이 부여받은 아이디와 일치되는 회원임을 확인하고 비밀의 보호를 위해 회원 자신이 정한 문자(특수문자 포함)와 숫자의 조합을 의미합니다.
+8. '콘텐츠'란 정보통신망법의 규정에 따라 정보통신망에서 사용되는 부호 ·문자·음성·음향·이미지 또는 영상 등으로 정보 형태의 글, 사진, 동영상 및 각종 파일과 링크 등을 말합니다.
+
+## 제3조(약관 외 준칙)
+
+이 약관에서 정하지 아니한 사항에 대해서는 법령 또는 회사가 정한 서비스의 개별약관, 운영정책 및 규칙 등(이하 세부지침)의 규정에 따릅니다. 또한 본 약관과 세부지침이 충돌할 경우에는 세부지침에 따릅니다.
+
+## 제4조(약관의 효력과 변경)
+
+1. 이 약관은 킬링파트(이)가 제공하는 모든 인터넷서비스에 게시하여 공시합니다. '회사'는 ‘전자상거래 등에서의 소비자보호에 관한 법률(이하 '전자상거래법'이라 함)', '약관의 규제에 관한 법률(이하 '약관규제법'이라 함)', '전자문서 및 전자거래 기본법(이하 '전자문서법'이라 함)', ‘전자금융거래법‘, '정보통신망 이용촉진 및 정보보호 등에 관한 법률(이하 '정보통신망법'이라 함)', '소비자기본법' 등 관계 법령(이하 '관계법령' 이라 함)에 위배되지 않는 범위 내에서 이 약관을 변경할 수 있으며, 회사는 약관이 변경되는 경우에 변경된 약관의 내용과 시행일을 정하여, 그 시행일로부터 최소 7일 (이용자에게 불리하거나 중대한 사항의 변경은 30일) 이전부터 시행일 후 상당한 기간 동안 공지하고, 기존 이용자에게는 변경된 약관, 적용일자 및 변경사유(변경될 내용 중 중요사항에 대한 설명을 포함)를 별도의 전자적 수단(전자우편, 문자메시지, 서비스 내 전자쪽지발송, 알림 메시지를 띄우는 등의 방법)으로 개별 통지합니다. 변경된 약관은 공지하거나 통지한 시행일로부터 효력이
+발생합니다.
+2. 회사가 제1항에 따라 개정약관을 공지 또는 통지하는 경우 '변경에 동의하지 아니한 경우 공지일 또는 통지를 받은 날로부터 7일(이용자에게 불리하거나 중대한 사항의 변경인 경우에는 30일) 내에 계약을 해지할 수 있으며, 계약해지의 의사표시를 하지 아니한 경우에는 변경에 동의한 것으로 본다.' 라는 취지의 내용을 함께 통지합니다.
+3. 이용자가 제2항의 공지일 또는 통지를 받은 날로부터 7일(또는 이용자에게 불리하거나 중대한 사항의 변경인 경우에는 30일)내에 변경된 약관에 대해 거절의 의사를 표시하지 않았을 때에는 본 약관의 변경에 동의한 것으로 간주합니다.
+
+## 제5조(이용자에 대한 통지)
+
+1. 회사는 이 약관에 별도 규정이 없는 한 이용자에게 전자우편, 문자메시지(SMS), 전자쪽지, 푸쉬(Push)알림 등의 전자적 수단을 이용하여 통지할 수 있습니다.
+2. 회사는 이용자 전체에 대한 통지의 경우 7일 이상 회사가 운영하는 웹사이트 내의 게시판에 게시함으로써 제1항의 통지에 갈음할 수 있습니다. 다만, 이용자 본인의 거래와 관련하여 중대한 영향을 미치는 사항에 대하여는 제1항의 개별 통지를 합니다.
+3. 회사는 이용자의 연락처 미기재, 변경 후 미수정, 오기재 등으로 인하여 개별 통지가 어려운 경우에 한하여 전항의 공지를 함으로써 개별 통지를 한 것으로 간주합니다.
+
+## 제6조(이용계약의 체결)
+
+이용계약은 다음의 경우에 체결됩니다.
+
+1. 이용자가 회원으로 가입하고자 하는 경우 이용자가 약관의 내용에 대하여 동의를 한 다음 회원가입신청을 하고 회사가 이러한 신청에 대하여 승낙한 때
+2. 이용자가 회원 가입 없이 이용할 수 있는 서비스에 대하여 회원 가입의 신청없이 서비스를 이용하고자 하는 경우에는 회사 서비스 이용을 위해 결제하는 때
+3. 이용자가 회원가입 없이 이용할 수 있는 서비스에 대하여 회원가입의 신청없이 무료 서비스를 이용하고자 하는 경우에는 그 무료 서비스와 관련된 사항의 저장 등 부가서비스를 이용하면서 위 1호 및 2호의 절차를 진행한 때
+
+## 제7조(회원가입에 대한 승낙)
+
+1. 회사는 이용계약에 대한 요청이 있을 때 서비스 이용을 승낙함을 원칙으로 합니다.
+2. 제1항에 따른 신청에 있어 회사는 서비스 제공에 필요한 경우 전문기관을 통한 실명확인 및 본인인증을 요청할 수 있습니다.
+3. 회사는 서비스 관련 설비의 여유가 없거나, 기술상 또는 업무상 문제가 있는 경우에는 승낙을 유보할 수 있습니다.
+4. 제3항에 따라 서비스 이용을 승낙하지 아니하거나 유보한 경우, 회사는 원칙적으로 이를 서비스 이용 신청자에게 알리도록 합니다. 단, 회사의 귀책사유 없이 이용자에게 알릴 수 없는 경우에는 예외로 합니다.
+5. 이용계약의 성립 시기는 제6조 제1호의 경우에는 회사가 가입완료를 신청절차 상에서 표시한 시점, 제6조 제2호의 경우에는 결제가 완료되었다는 표시가 된 시점으로 합니다.
+6. 회사는 회원에 대해 회사정책에 따라 등급별로 구분하여 이용시간, 이용횟수, 서비스 메뉴 등을 세분하여 이용에 차등을 둘 수 있습니다.
+7. 회사는 회원에 대하여 '영화및비디오물의진흥에관한법률' 및 '청소년보호법' 등에 따른 등급 및 연령 준수를 위하여 이용제한이나 등급별 제한을 둘 수 있습니다.
+
+## 제8조(회원정보의 변경)
+
+1. 회원은 개인정보관리화면을 통하여 언제든지 본인의 개인정보를 열람하고 수정할 수 있습니다. 다만, 서비스 관리를 위해 필요한 실명, 아이디 등은 수정이 불가능합니다.
+2. 회원은 회원가입신청 시 기재한 사항이 변경되었을 경우 온라인으로 수정을 하거나 전자우편 기타 방법으로 회사에 대하여 그 변경사항을 알려야 합니다.
+3. 제2항의 변경사항을 회사에 알리지 않아 발생한 불이익에 대하여는 회원에게 책임이 있습니다.
+
+## 제9조(회원정보의 관리 및 보호)
+
+1. 회원의 아이디(ID)와 비밀번호에 관한 관리책임은 회원에게 있으며, 이를 제3자가 이용하도록 하여서는 안 됩니다.
+2. 회사는 회원의 아이디(ID)가 개인정보 유출 우려가 있거나, 반사회적 또는 공서양속에 어긋나거나, 회사 또는 서비스의 운영자로 오인할 우려가 있는 경우, 해당 아이디(ID)의 이용을 제한 할 수있습니다.
+3. 회원은 아이디(ID) 및 비밀번호가 도용되거나 제3자가 사용하고 있음을 인지한 경우에는 이를 즉시 회사에 통지하고 안내에 따라야 합니다.
+4. 제3항의 경우 해당 회원이 회사에 그 사실을 통지하지 않거나, 통지하였으나 회사의 안내에 따르지 않아 발생한 불이익에 대하여 회사는 책임지지 않습니다.
+
+## 제10조(회사의 의무)
+
+1. 회사는 계속적이고 안정적인 서비스의 제공을 위하여 설비에 장애가 생기거나 멸실된 때에는 이를 지체 없이 수리 또는 복구하며, 다음 각 호의 사유 발생 시 부득이한 경우 예고 없이 서비스의 전부 또는 일부의 제공을 일시 중지할 수 있습니다. 이 경우 그 사유 및 중지 기간 등을 이용자에게 지체 없이 사후 공지합니다.
+
+가. 시스템의 긴급점검, 증설, 교체, 시설의 보수 또는 공사를 하기 위하여 필요한 경우
+나. 새로운 서비스를 제공하기 위하여 시스템교체가 필요하다고 판단되는 경우
+다. 시스템 또는 기타 서비스 설비의 장애, 유무선 Network 장애 등으로 정상적인 서비스 제공이 불가능할 경우
+라. 국가비상사태, 정전, 불가항력적 사유로 인한 경우
+2. 회사는 이용계약의 체결, 계약사항의 변경 및 해지 등 이용자와의 계약관련 절차 및 내용 등에 있어 이용자에게 편의를 제공하도록 노력합니다.
+3. 회사는 대표자의 성명, 상호, 주소, 전화번호, 모사전송번호(FAX), 통신판매업 신고번호, 이용약관, 개인정보취급방침 등을 이용자가 쉽게 알 수 있도록 온라인 서비스 초기화면에 게시합니다.
+
+## 제11조(개인정보보호)
+
+1. 회사는 이용자들의 개인정보를 중요시하며, 정보통신망 이용촉진 및 정보보호 등에 관한 법률, 개인정보보호법 등 관련 법규를 준수하기 위해 노력합니다. 회사는 개인정보보호정책을 통하여 이용자가 제공하는 개인정보가 어떠한 용도와 방식으로 이용되고 있으며 개인정보보호를 위해 어떠한 조치가 취해지고 있는지 알려드립니다.
+2. 회사가 이용자의 개인정보의 보호 및 사용에 대해서 관련 법규 및 회사의 개인정보처리방침을 적용합니다. 다만, 회사에서 운영하는 웹 사이트 등에서 링크된 외부 웹페이지에서는 회사의 개인정보처리방침이 적용되지 않습니다.
+
+## 제12조(이용자의 의무)
+
+1. 이용자는 이용자가입을 통해 이용신청을 하는 경우 사실에 근거하여 신청서를 작성해야 합니다. 이용자가 허위, 또는 타인의 정보를 등록한 경우 회사에 대하여 일체의 권리를 주장할 수 없으며, 회사는 이로 인하여 발생한 손해에 대하여 책임을 부담하지 않습니다.
+2. 이용자는 본 약관에서 규정하는 사항과 기타 회사가 정한 제반 규정, 회사가 공지하는 사항을 준수하여야 합니다. 또한 이용자는 회사의 업무를 방해하는 행위 및 회사의 명예를 훼손하는 행위를 하여서는 안 됩니다.
+3. 이용자는 주소, 연락처, 전자우편 주소 등 회원정보가 변경된 경우 즉시 온라인을 통해 이를 수정해야 합니다. 이 때 변경된 정보를 수정하지 않거나 수정이 지연되어 발생하는 책임은 이용자가 지게 됩니다.
+4. 이용자는 이용자에게 부여된 아이디와 비밀번호를 직접 관리해야 합니다. 이용자의 관리 소홀로 발생한 문제는 회사가 책임을 부담하지 않습니다.
+5. 이용자가 아이디, 닉네임, 기타 서비스 내에서 사용되는 명칭 등을 선정할 때에는 다음 각 호에 해당하는 행위를 해서는 안 됩니다.
+
+가. 회사가 제공하는 서비스의 공식 운영자를 사칭하거나 이와 유사한 명칭을 사용하여 다른 이용자에게 혼란을 주는 행위
+나. 선정적이고 음란한 내용이 포함된 명칭을 사용하는 행위
+다. 제3자의 상표권, 저작권 등 권리를 침해할 가능성이 있는 명칭을 사용하는 행위
+라. 제3자의 명예를 훼손하거나, 그 업무를 방해할 가능성이 있는 명칭을 사용하는 행위
+마. 기타 반사회적이고 관계법령에 저촉되는 내용이 포함된 명칭을 사용하는 행위
+6. 이용자는 회사의 명시적 동의가 없는 한 서비스 이용 권한, 기타 이용 계약상의 지위에 대하여 매도, 증여, 담보제공 등 처분행위를 할 수 없습니다.
+7. 본 조와 관련하여 서비스 이용에 있어 주의사항 등 그 밖의 자세한 내용은 운영정책으로 정하며, 이용자가 서비스 이용약관 및 운영정책을 위반하는 경우 서비스 이용제한, 민형사상의 책임 등 불이익이 발생할 수 있습니다.
+
+## 제13조(서비스의 제공)
+
+1. 회사의 서비스는 연중무휴, 1일 24시간 제공을 원칙으로 합니다. 다만 회사 시스템의 유지 보수를 위한 점검, 통신장비의 교체 등 특별한 사유가 있는 경우 서비스의 전부 또는 일부에 대하여 일시적인 제공 중단이 발생할 수 있습니다.
+2. 회사가 제공하는 개별 서비스에 대한 구체적인 안내사항은 개별 서비스 화면에서 확인할 수 있습니다.
+3. 회사가 제공하는 서비스의 내용은 다음과 같습니다.
+가. 음악 콘텐츠의 특정 구간 기록 및 저장 기능
+나. 킬링파트 관련 게시물 작성, 편집, 공개, 공유 기능
+다. 다른 이용자가 작성한 킬링파트 및 관련 콘텐츠의 탐색, 조회 기능
+라. 모바일 애플리케이션 및 기타 전자적 방식으로 제공되는 관련 제반 서비스
+
+## 제14조(서비스의 제한 등)
+
+1. 회사는 전시, 사변, 천재지변 또는 이에 준하는 국가비상사태가 발생하거나 발생할 우려가 있는 경우와 전기통신사업법에 의한 기간통신사업자가 전기통신서비스를 중지하는 등 부득이한 사유가 있는 경우에는 서비스의 전부 또는 일부를 제한하거나 중지할 수 있습니다.
+2. 무료서비스는 전항의 규정에도 불구하고, 회사의 운영정책 등의 사유로 서비스의 전부 또는 일부가 제한되거나 중지될 수 있으며, 유료로 전환될 수 있습니다.
+3. 회사는 서비스의 이용을 제한하거나 정지하는 때에는 그 사유 및 제한기간, 예정 일시 등을 지체없이 이용자에게 알립니다.
+4. 회사는 사전에 결제정보를 입력 받고, 무료로 제공중인 서비스를 유료로 전환할 경우, 그 사유와 유료 전환 예정 일시를 통지하고 유료 전환에 대한 이용자의 동의를 받습니다.
+
+## 제15조(서비스의 해제·해지 및 탈퇴 절차)
+
+1. 이용자가 이용 계약을 해지하고자 할 때는 언제든지 홈페이지 상의 이용자 탈퇴 신청을 통해 이용계약 해지를 요청할 수 있습니다. 단, 신규가입 후 일정 시간 동안 서비스 부정이용 방지 등의 사유로 즉시 탈퇴가 제한될 수 있습니다.
+2. 회사는 이용자가 본 약관에서 정한 이용자의 의무를 위반한 경우 등 비정상적인 이용 또는 부당한 이용과 이용자 금지프로그램 사용하는 경우 또는 타인의 명예를 훼손하거나 모욕하는 방송과 게시물을 작성한 경우 이러한 행위를 금지하거나 삭제를 요청하였음에도 불구하고 최초의 금지 또는 삭제 요청을 포함하여 2회 이상 누적되는 경우 이용자에게 통지하고, 계약을 해지할 수 있습니다.
+3. 회사는 이용자의 청약철회, 해제 또는 해지의 의사표시를 수신한 후 그 사실을 이용자에게 회신합니다. 회신은 이용자가 회사에 대하여 통지한 방법 중 하나에 의하고, 이용자가 회사에 대하여 통지한 연락처가 존재하지 않는 경우에는 회신하지 않을 수 있습니다.
+
+## 제16조(손해배상)
+
+1. 회사 또는 이용자는 상대방의 귀책에 따라 손해가 발생하는 경우 손해배상을 청구할 수 있습니다. 다만,
+회사는 무료서비스의 장애, 제공 중단, 보관된 자료 멸실 또는 삭제, 변조 등으로 인한 손해에 대하여는 배상책임을 부담하지 않습니다.
+2. 회사가 제공하는 서비스의 이용과 관련하여 회사의 운영정책 및 개인 정보 보호정책, 기타 서비스별 이용약관에서 정하는 내용에 위반하지 않는 한 회사는 어떠한 손해에 대하여도 책임을 부담하지 않습니다.
+
+## 제17조(면책사항)
+
+1. 회사는 천재지변 또는 이에 준하는 불가항력으로 인하여 서비스를 제공할 수 없는 경우에는 서비스 제공에 관한 책임을 지지 않습니다.
+2. 회사는 이용자의 귀책사유로 인한 서비스 이용장애에 대하여 책임을 지지 지 않습니다.
+3. 회사는 이용자가 서비스를 이용하며 기대하는 수익을 얻지 못한 것에 대하여 책임 지지 않으며 서비스를 통하여 얻은 자료로 인한 손해 등에 대하여도 책임을 지지 않습니다.
+4. 회사는 이용자가 웹페이지에 게재한 내용의 신뢰도, 정확성 등 내용에 대해서는 책임지지 않으며, 이용자 상호간 또는 이용자와 제3자 상호간 서비스를 매개로 발생한 분쟁에 개입하지 않습니다.
+
+## 제18조(정보의 제공 및 광고의 게재)
+
+1. 회사는 이용자가 서비스 이용 중 필요하다고 인정되는 각종 정보 및 광고를 배너 게재, 전자우편(E-Mail), 휴대폰 메세지, 전화, 우편 등의 방법으로 이용자에게 제공(또는 전송)할 수 있습니다. 다만, 이용자는 이를 원하지 않을 경우 회사가 제공하는 방법에 따라 수신을 거부할 수 있습니다.
+2. 이용자가 수신 거부를 한 경우에도 이용약관, 개인정보보호정책, 기타 이용자의 이익에 영향을 미칠 수 있는 중요한 사항의 변경 등 '정보통신망이용촉진 및 정보보호 등에 관한 법률'에서 정하는 사유 등 이용자가 반드시 알고 있어야 하는 사항에 대하여는 전자우편 등의 방법으로 정보를 제공할 수 있습니다.
+3. 제1항 단서에 따라 이용자가 수신 거부 조치를 취한 경우 이로 인하여 회사가 거래 관련 정보, 이용 문의에 대한 답변 등의 정보를 전달하지 못한 경우 회사는 이로 인한 책임이 없습니다.
+4. 회사는 '정보통신망법' 시행령에 따라 2년마다 영리 목적의 광고정 정보 전송에 대한 수신동의 여부를 확인합니다.
+5. 회사는 광고주의 판촉 활동에 이용자가 참여하거나, 거래의 결과로서 발생하는 손실 또는 손해에 대하여는 책임을 지지 않습니다.
+
+## 제19조(권리의 귀속)
+
+1. 회사가 제공하는 서비스에 대한 저작권 등 지식재산권은 회사에 귀속 됩니다.
+2. 회사는 서비스와 관련하여 이용자에게 회사가 정한 조건 따라 회사가 제공하는 서비스를 이용할 수 있는 권한만을 부여하며, 이용자는 이를 양도, 판매, 담보제공 하는 등 처분행위를 할 수 없습니다.
+3. 제1항의 규정에도 불구하고 이용자가 직접 작성한 콘텐츠 및 회사의 제휴계약에 따라 제공된 저작물에 대한 지식재산권은 회사에 귀속되지 않습니다.
+
+## 제20조(콘텐츠의 관리)
+
+1. 회원이 작성 또는 창작한 콘텐츠가 '개인정보보호법' 및 '저작권법' 등 관련 법에 위반되는 내용을 포함하는 경우, 관리자는 관련 법이 정한 절차에 따라 해당 콘텐츠의 게시중단 및 삭제 등을 요청할 수 있으며, 회사는 관련 법에 따라 조치를 취하여야 합니다.
+2. 회사는 전항에 따른 권리자의 요청이 없는 경우라도 권리침해가 인정될 만한 사유가 있거나 기타 회사 정책 및 관련 법에 위반되는 경우에는 관련 법에 따라 해당 콘텐츠에 대해 임시조치 등을 취할 수 있습니다.
+
+## 제21조(콘텐츠의 저작권)
+
+1. 이용자가 서비스 내에 게시한 콘텐츠의 저작권은 해당 콘텐츠의 저작자에게 귀속됩니다.
+2. 제1항에 불구하고 회사는 서비스의 운영, 전시, 전송, 배포, 홍보 등의 목적으로 별도의 허락 없이 무상으로 저작권법 및 공정한 거래관행에 합치되는 범위 내에서 다음 각 호와 같이 회원이 등록한 콘텐츠를 사용할 수 있습니다.
+
+가. 서비스 내에서 이용자가 작성한 콘텐츠의 복제, 수정, 전시, 전송, 배포 등 저작권을 침해하지
+않는 범위 내의 2차적저작물 또는 편집 저작물 작성을 위한 사용. 다만, 해당 콘텐츠를
+등록한 이용자가 해당 콘텐츠의 삭제 또는 사용 중지를 요청하는 경우 회사는 관련 법에 따라
+보존해야하는 사항을 제외하고 관련 콘텐츠를 모두 삭제 또는 사용중지합니다.
+나. 서비스의 운영, 홍보, 서비스 개선 및 새로운 서비스 개발을 위한 범위 내의 사용
+다. 미디어, 통신사 등을 통한 홍보목적으로 이용자의 콘텐츠를 제공, 전시하도록 하는 등의
+사용.
+
+## 제22조(관할법원 및 준거법)
+
+서비스와 관련하여 분쟁이 발생한 경우 관할법원은 민사소송법에 따른 관할법원으로 정하며, 준거법은
+대한민국의 법령을 적용합니다.
+
+부칙
+제1조(시행일)
+본 약관은 2026.03.18.부터 시행됩니다.
+"""
+}

--- a/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
+++ b/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift
@@ -377,60 +377,73 @@ private struct NameSetupScreen: View {
     @ObservedObject var viewModel: InitialSetupFlowViewModel
 
     var body: some View {
-        VStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: AppSpacing.s) {
-                Text("사용하실 이름이 무엇인가요?")
-                    .font(AppFont.paperlogy7Bold(size: 28))
-                    .foregroundStyle(.white)
+        GeometryReader { geometry in
+            let horizontalPadding = AppSpacing.l
+            let safeAreaBottomInset = geometry.safeAreaInsets.bottom
+            let isKeyboardPresented = safeAreaBottomInset > 80
+            let bottomPadding = isKeyboardPresented
+                ? AppSpacing.s
+                : safeAreaBottomInset + AppSpacing.l
+            let contentTopOffset = max(
+                geometry.safeAreaInsets.top + AppSpacing.xl,
+                geometry.size.height * 0.22
+            )
 
-                Text("이름은 언제든지 바꿀 수 있습니다")
-                    .font(AppFont.paperlogy4Regular(size: 14))
-                    .foregroundStyle(.white.opacity(0.72))
+            VStack(spacing: 0) {
+                VStack(alignment: .leading, spacing: AppSpacing.s) {
+                    Text("사용하실 이름이 무엇인가요?")
+                        .font(AppFont.paperlogy7Bold(size: 28))
+                        .foregroundStyle(.white)
 
-                Text("*이름은 1~20자, 영어/한글/숫자/공백만 사용 가능")
-                    .font(AppFont.paperlogy4Regular(size: 12))
-                    .foregroundStyle(.white.opacity(0.55))
-                    .padding(.top, AppSpacing.xs)
+                    Text("이름은 언제든지 바꿀 수 있습니다")
+                        .font(AppFont.paperlogy4Regular(size: 14))
+                        .foregroundStyle(.white.opacity(0.72))
 
-                TextField("이름 입력", text: $viewModel.nameDraft)
-                    .font(AppFont.paperlogy5Medium(size: 16))
-                    .foregroundStyle(.white)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .padding(.horizontal, AppSpacing.m)
-                    .padding(.vertical, AppSpacing.m)
-                    .background(Color.white.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                    .overlay {
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                    Text("*이름은 1~20자, 영어/한글/숫자/공백만 사용 가능")
+                        .font(AppFont.paperlogy4Regular(size: 12))
+                        .foregroundStyle(.white.opacity(0.55))
+                        .padding(.top, AppSpacing.xs)
+
+                    TextField("이름 입력", text: $viewModel.nameDraft)
+                        .font(AppFont.paperlogy5Medium(size: 16))
+                        .foregroundStyle(.white)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding(.horizontal, AppSpacing.m)
+                        .padding(.vertical, AppSpacing.m)
+                        .background(Color.white.opacity(0.08))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                        }
+
+                    if let validation = viewModel.validateName(viewModel.nameDraft), !viewModel.nameDraft.isEmpty {
+                        Text(validation)
+                            .font(AppFont.paperlogy4Regular(size: 13))
+                            .foregroundStyle(.red.opacity(0.95))
+                    } else if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .font(AppFont.paperlogy4Regular(size: 13))
+                            .foregroundStyle(.red.opacity(0.95))
                     }
-
-                if let validation = viewModel.validateName(viewModel.nameDraft), !viewModel.nameDraft.isEmpty {
-                    Text(validation)
-                        .font(AppFont.paperlogy4Regular(size: 13))
-                        .foregroundStyle(.red.opacity(0.95))
-                } else if let errorMessage = viewModel.errorMessage {
-                    Text(errorMessage)
-                        .font(AppFont.paperlogy4Regular(size: 13))
-                        .foregroundStyle(.red.opacity(0.95))
                 }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, AppSpacing.l)
-            .padding(.top, AppSpacing.xl)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.top, contentTopOffset)
 
-            Spacer(minLength: 0)
+                Spacer(minLength: 0)
 
-            PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
-                Task {
-                    await viewModel.submitName()
+                PrimaryButton(title: "다음", isLoading: viewModel.isLoading) {
+                    Task {
+                        await viewModel.submitName()
+                    }
                 }
+                .disabled(!viewModel.canSubmitName || viewModel.isLoading)
+                .opacity((viewModel.canSubmitName && !viewModel.isLoading) ? 1 : 0.45)
+                .padding(.horizontal, horizontalPadding)
+                .padding(.bottom, bottomPadding)
             }
-            .disabled(!viewModel.canSubmitName || viewModel.isLoading)
-            .opacity((viewModel.canSubmitName && !viewModel.isLoading) ? 1 : 0.45)
-            .padding(.horizontal, AppSpacing.l)
-            .padding(.bottom, AppSpacing.xl)
         }
         .background(
             LinearGradient(

--- a/KillingPartTests/InitialSetupFlowTests.swift
+++ b/KillingPartTests/InitialSetupFlowTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import KillingPart
+
+@MainActor
+struct InitialSetupFlowTests {
+    @Test
+    func validatesNameRules() {
+        let viewModel = InitialSetupFlowViewModel(settings: .make())
+
+        #expect(viewModel.validateName("") != nil)
+        #expect(viewModel.validateName("홍길동 123") == nil)
+        #expect(viewModel.validateName("A B C") == nil)
+        #expect(viewModel.validateName(String(repeating: "a", count: 21)) != nil)
+        #expect(viewModel.validateName("name*") != nil)
+    }
+
+    @Test
+    func validatesTagRules() {
+        let viewModel = InitialSetupFlowViewModel(settings: .make())
+
+        #expect(viewModel.validateTag("ab") != nil)
+        #expect(viewModel.validateTag("abcd") == nil)
+        #expect(viewModel.validateTag("ab..cd") != nil)
+        #expect(viewModel.validateTag(".abcd") != nil)
+        #expect(viewModel.validateTag("abcd.") != nil)
+        #expect(viewModel.validateTag("abCD") != nil)
+        #expect(viewModel.validateTag("valid_tag.01") == nil)
+    }
+
+    @Test
+    func postLoginRoutePrefersUpdatePromptAndSetupFlow() async {
+        let settings = UserInitSettingsResponse(
+            app: UserAppUpdateStatus(needsForceUpdate: true, needsOptionalUpdate: true),
+            needsPolicyAgreement: true,
+            needsTagSetup: true,
+            policies: [
+                .init(
+                    policyType: .serviceTerms,
+                    required: true,
+                    agreed: false,
+                    currentRevision: 0,
+                    latestRevision: 1
+                ),
+                .init(
+                    policyType: .privacy,
+                    required: true,
+                    agreed: false,
+                    currentRevision: 0,
+                    latestRevision: 1
+                )
+            ]
+        )
+
+        let userService = MockUserService(settings: settings)
+        let tokenStore = MockTokenStore(hasSessionTokens: true)
+        let viewModel = AppViewModel(
+            userService: userService,
+            tokenStore: tokenStore
+        )
+
+        await viewModel.resolvePostLoginFlow()
+
+        #expect(viewModel.currentStep == .setup)
+        #expect(viewModel.updatePrompt == .force)
+        #expect(viewModel.setupFlowViewModel?.step == .policyAgreement)
+    }
+
+    @Test
+    func postLoginRouteGoesMainWhenNoSetupRequired() async {
+        let settings = UserInitSettingsResponse(
+            app: UserAppUpdateStatus(needsForceUpdate: false, needsOptionalUpdate: true),
+            needsPolicyAgreement: false,
+            needsTagSetup: false,
+            policies: []
+        )
+
+        let userService = MockUserService(settings: settings)
+        let tokenStore = MockTokenStore(hasSessionTokens: true)
+        let viewModel = AppViewModel(
+            userService: userService,
+            tokenStore: tokenStore
+        )
+
+        await viewModel.resolvePostLoginFlow()
+
+        #expect(viewModel.currentStep == .main)
+        #expect(viewModel.updatePrompt == .optional)
+        #expect(viewModel.setupFlowViewModel == nil)
+    }
+}
+
+private final class MockUserService: UserServicing {
+    private let settings: UserInitSettingsResponse
+
+    init(settings: UserInitSettingsResponse) {
+        self.settings = settings
+    }
+
+    func fetchMyUser() async throws -> UserModel {
+        .init(
+            userId: 1,
+            username: "test",
+            tag: "tester",
+            identifier: "KAKAO-1",
+            profileImageUrl: "",
+            userRoleType: "USER",
+            socialType: "KAKAO"
+        )
+    }
+
+    func fetchInitSettings() async throws -> UserInitSettingsResponse { settings }
+
+    func submitPolicyAgreement(agreements: [PolicyAgreementItem]) async throws {}
+
+    func fetchUserStatics(userId: Int) async throws -> UserStaticsModel {
+        .init(fanCount: 0, pickCount: 0, killingPartCount: 0)
+    }
+
+    func searchUsers(searchCond: String?, page: Int, size: Int) async throws -> UserSearchResponse {
+        .init(content: [], page: .init(size: 0, number: 0, totalElements: 0, totalPages: 0))
+    }
+
+    func deleteMyProfileImage() async throws -> UserModel {
+        try await fetchMyUser()
+    }
+
+    func issuePresignedURL() async throws -> PresignedURLResponse {
+        .init(id: 0, presignedUrl: "")
+    }
+
+    func uploadImageToPresignedURL(imageData: Data, presignedURL: URL) async throws {}
+
+    func updateMyProfileImage(request: UpdateMyProfileImageRequest) async throws -> UserModel {
+        try await fetchMyUser()
+    }
+
+    func updateMyUsername(username: String) async throws -> UserModel {
+        .init(
+            userId: 1,
+            username: username,
+            tag: "tester",
+            identifier: "KAKAO-1",
+            profileImageUrl: "",
+            userRoleType: "USER",
+            socialType: "KAKAO"
+        )
+    }
+
+    func updateMyTag(tag: String) async throws -> UserModel {
+        .init(
+            userId: 1,
+            username: "test",
+            tag: tag,
+            identifier: "KAKAO-1",
+            profileImageUrl: "",
+            userRoleType: "USER",
+            socialType: "KAKAO"
+        )
+    }
+}
+
+private final class MockTokenStore: TokenStoring {
+    var accessToken: String?
+    var refreshToken: String?
+    var hasSessionTokens: Bool
+
+    init(hasSessionTokens: Bool) {
+        self.hasSessionTokens = hasSessionTokens
+        self.accessToken = hasSessionTokens ? "access" : nil
+        self.refreshToken = hasSessionTokens ? "refresh" : nil
+    }
+
+    func save(accessToken: String, refreshToken: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+        hasSessionTokens = true
+    }
+
+    func clearTokens() {
+        accessToken = nil
+        refreshToken = nil
+        hasSessionTokens = false
+    }
+}
+
+private extension UserInitSettingsResponse {
+    static func make() -> UserInitSettingsResponse {
+        UserInitSettingsResponse(
+            app: .init(needsForceUpdate: false, needsOptionalUpdate: false),
+            needsPolicyAgreement: false,
+            needsTagSetup: true,
+            policies: []
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용

- [x] 기존 온보딩 제거 -> 바로 로그인 화면
- [x] 로그인 이후 초기 설정 상태(```/api/users/init-settings```) API 연동 및 조회
- [x] needsPolicyAgreement - True -> 메인화면, 스택 초기화
- [x] needsPolicyAgreement - False -> 약관동의 화면
- [x] needsTagSetup - False -> 태그 설정 페이지
- [ ] app.needsForceUpdate - True -> 다이얼로그 및 앱스토어로 리다이렉팅 ( 테스트 필요 ) 
- [ ] app.needsOptionalUpdate - True -> 업데이트 필요 다이얼로그 추가 ( 테스트 필요 ) 

### 약관 동의 화면
- [x] 기존 로그인 화면과 동일하게 구성
- [x] 로그인 컴포넌트 자리에 이용약관, 완료 버튼 추가
- [x] 완료버튼 활성화 여부는 이용약관 2개다 체크 됐을 경우
- [x] 전문확인 다이얼로그 추가
- [x] 완료 버튼 -> 이름 입력 페이지
- [x] 약관 동의 처리(```/api/users/policy-agreement```) API 연동

### 이름 설정 페이지
- [x] 이름 값 필터링 (1~20자 사이, 영어, 한글, 숫자, 공백만 사용)
- [x] ```/api/users/my/names``` api 호출
- [x] 다음 버튼 -> 태그 수정 페이지

### 태그 설정 페이지
- [x] 태그 값 필터링 (4~30자 사이, 영문 소문자, 숫자, '_', '*' 만 사용, '.'으로 시작, 끝내기 불가, 연속 사용 불가)
- [x] ```/api/users/my/tags ``` api 호출
- [x] 다음 버튼 -> 튜토리얼 선택여부 페이지

### 튜토리얼 선택여부 페이지
- [x] 건너뛰기 버튼 -> 메인화면, 스택 초기화
- [x] 추가하기 -> 곡 선택 페이지

### 곡 선택 페이지
- [x] 우측 상단 건너뛰기 버튼 -> 메인화면, 스택 초기화
- [x] @AddTabView 래퍼런스로 작업
- [x] 곡 선택 시 -> 구간 정하기 페이지

- **아래 페이지부터는 상 하단 UI 고정**

### 구간 정하기 페이지
- [x] 우측 상단 건너뛰기 버튼 -> 메인화면, 스택 초기화
- [x] @AddSearchDetailView 래퍼런스로 작업
- [x] 구간 자르는 부분만 불투명 나머지 반투명 처리, 아무곳이나 터치 -> 다시 전부 불투명
- [x] 음악 일기 작성 완료 -> 킬링파트 홈 탭 튜토리얼 페이지

### 킬링파트 홈 탭 튜토리얼 페이지
- [x] @MyTabView, @MyCollectionView,@MyCollectionMyKillingPartSectionView,@MusicCalendarView 래퍼런스로 작업
- [x] 우측 상단 건너뛰기 
- [x] ```/api/diaries/my``` api 연동
- [x] 상단 토글 탭 내 컬렉션, 뮤직 캘린더만 유지
- [x] ```/api/diaries/my/calendar``` 로 캘린더 데이터 조회
- [x] 다음 -> 홈 상세 다이어리 튜토리얼 페이지

### 홈 상세 다이어리 튜토리얼 페이지
- [x] @MyCollectionDiary 래퍼런스
- [x] 다이어리는 아까 추가한 다이어리 인덱스 0번째꺼 id로 라우팅
- [x] 다음 -> 알림 튜토리얼 페이지

### 알림 튜토리얼 페이지 (보류)
- [x] 알림 목록 페이지 
- [x] 우측 상단 건너뛰기 
- [x] 다음 -> 최종 튜토리얼 페이지

### 최종 튜토리얼 페이지
- [x] 시작하기 -> 메인화면, 스택 초기화

---

### 새롭게 추가할 API
- [x] 약관 동의 처리 API 연동
- [x] 초기 설정 상태 조회 API 연동