### PR TITLE
feat: 킬링파트 자르기 리뉴얼

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,12 @@
 {
   "permissions": {
     "allow": [
-      "Bash(awk '/private struct TutorialDiaryDetailScreen/,/private struct TutorialNotificationScreen/' /Users/ibyeongchan/Desktop/KillingPart/KillingPoint-iOS/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift)"
+      "Bash(awk '/private struct TutorialDiaryDetailScreen/,/private struct TutorialNotificationScreen/' /Users/ibyeongchan/Desktop/KillingPart/KillingPoint-iOS/KillingPart/Views/Screens/Setup/InitialSetupFlowView.swift)",
+      "Bash(xcodebuild -list)",
+      "Bash(sed -n '/Schemes:/,$p')",
+      "Bash(xcrun simctl *)",
+      "Bash(xcodebuild -scheme KillingPart -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -configuration Debug build)",
+      "Bash(xcodebuild -scheme KillingPart -destination 'id=F8EF57C6-FEF3-4767-897D-C56BADD80E69' -configuration Debug build)"
     ]
   }
 }

--- a/KillingPart.xcodeproj/project.pbxproj
+++ b/KillingPart.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -483,7 +483,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.12;
+				MARKETING_VERSION = 1.2.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -503,7 +503,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 47;
+				CURRENT_PROJECT_VERSION = 48;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -528,7 +528,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.12;
+				MARKETING_VERSION = 1.2.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/KillingPart.xcodeproj/project.pbxproj
+++ b/KillingPart.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -483,7 +483,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.13;
+				MARKETING_VERSION = 1.2.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -503,7 +503,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = KillingPart/KillingPart.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 48;
+				CURRENT_PROJECT_VERSION = 49;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = GQ89YG5G9R;
 				ENABLE_APP_SANDBOX = YES;
@@ -528,7 +528,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.13;
+				MARKETING_VERSION = 1.2.14;
 				PRODUCT_BUNDLE_IDENTIFIER = com.killingpoint.killingpart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
+++ b/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
@@ -59,7 +59,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     private let minimumClipDuration: Double = 10
     private let maximumClipDurationLimit: Double = 30
     private let boundaryLoopDuration: Double = 2
-    private static let boundaryLoopHintDismissedKey = "add_search_detail_boundary_loop_hint_dismissed"
+    private static let boundaryLoopHintDismissedKey = "add_search_detail_boundary_loop_hint_dismissed_v2"
 
     init(
         track: SpotifySimpleTrack,

--- a/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
+++ b/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
@@ -27,6 +27,11 @@ struct AddSearchDetailPrefill {
     }
 }
 
+struct AddSearchDetailPlaybackSeekRequest: Equatable {
+    let seconds: Double
+    let token: Int
+}
+
 @MainActor
 final class AddSearchDetailViewModel: ObservableObject {
     @Published private(set) var videos: [YoutubeVideo] = []
@@ -35,6 +40,8 @@ final class AddSearchDetailViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var startSeconds: Double = 0
     @Published var endSeconds: Double = 0
+    @Published private(set) var playbackSeconds: Double = 0
+    @Published private(set) var playbackSeekRequest: AddSearchDetailPlaybackSeekRequest?
     @Published private(set) var currentStep: AddSearchDetailStep = .trim
     @Published var diaryContent: String = ""
     @Published var selectedScope: DiaryScope = .public
@@ -178,6 +185,20 @@ final class AddSearchDetailViewModel: ObservableObject {
 
         startSeconds = clampedStart
         endSeconds = clampedEnd
+    }
+
+    func updatePlaybackSeconds(_ seconds: Double) {
+        playbackSeconds = seconds
+    }
+
+    func requestPlayback(from seconds: Double) {
+        guard hasPlayableVideo else { return }
+        let upperBound = max(endSeconds - 0.3, startSeconds)
+        let clampedSeconds = min(max(seconds, startSeconds), upperBound)
+        playbackSeekRequest = AddSearchDetailPlaybackSeekRequest(
+            seconds: clampedSeconds,
+            token: (playbackSeekRequest?.token ?? 0) + 1
+        )
     }
 
     @discardableResult

--- a/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
+++ b/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
@@ -44,6 +44,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     @Published private(set) var playbackSeekRequest: AddSearchDetailPlaybackSeekRequest?
     @Published private(set) var boundaryLoopRange: ClosedRange<Double>?
     @Published private(set) var isHandleDragging = false
+    @Published private(set) var shouldShowBoundaryLoopHint: Bool
     @Published private(set) var currentStep: AddSearchDetailStep = .trim
     @Published var diaryContent: String = ""
     @Published var selectedScope: DiaryScope = .public
@@ -58,6 +59,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     private let minimumClipDuration: Double = 10
     private let maximumClipDurationLimit: Double = 30
     private let boundaryLoopDuration: Double = 2
+    private static let boundaryLoopHintDismissedKey = "add_search_detail_boundary_loop_hint_dismissed"
 
     init(
         track: SpotifySimpleTrack,
@@ -68,6 +70,9 @@ final class AddSearchDetailViewModel: ObservableObject {
         self.track = track
         self.youtubeService = youtubeService
         self.diaryService = diaryService
+        self.shouldShowBoundaryLoopHint = !UserDefaults.standard.bool(
+            forKey: Self.boundaryLoopHintDismissedKey
+        )
 
         if let prefill, applyPrefill(prefill) {
             hasLoaded = true
@@ -226,6 +231,12 @@ final class AddSearchDetailViewModel: ObservableObject {
     func setHandleDragging(_ isDragging: Bool) {
         guard isHandleDragging != isDragging else { return }
         isHandleDragging = isDragging
+    }
+
+    func dismissBoundaryLoopHint() {
+        guard shouldShowBoundaryLoopHint else { return }
+        shouldShowBoundaryLoopHint = false
+        UserDefaults.standard.set(true, forKey: Self.boundaryLoopHintDismissedKey)
     }
 
     func requestPlayback(from seconds: Double) {

--- a/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
+++ b/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
@@ -43,6 +43,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     @Published private(set) var playbackSeconds: Double = 0
     @Published private(set) var playbackSeekRequest: AddSearchDetailPlaybackSeekRequest?
     @Published private(set) var boundaryLoopRange: ClosedRange<Double>?
+    @Published private(set) var isHandleDragging = false
     @Published private(set) var currentStep: AddSearchDetailStep = .trim
     @Published var diaryContent: String = ""
     @Published var selectedScope: DiaryScope = .public
@@ -220,6 +221,11 @@ final class AddSearchDetailViewModel: ObservableObject {
 
     func deactivateBoundaryLoop() {
         boundaryLoopRange = nil
+    }
+
+    func setHandleDragging(_ isDragging: Bool) {
+        guard isHandleDragging != isDragging else { return }
+        isHandleDragging = isDragging
     }
 
     func requestPlayback(from seconds: Double) {

--- a/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
+++ b/KillingPart/ViewModels/Add/AddSearchDetailViewModel.swift
@@ -42,6 +42,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     @Published var endSeconds: Double = 0
     @Published private(set) var playbackSeconds: Double = 0
     @Published private(set) var playbackSeekRequest: AddSearchDetailPlaybackSeekRequest?
+    @Published private(set) var boundaryLoopRange: ClosedRange<Double>?
     @Published private(set) var currentStep: AddSearchDetailStep = .trim
     @Published var diaryContent: String = ""
     @Published var selectedScope: DiaryScope = .public
@@ -55,6 +56,7 @@ final class AddSearchDetailViewModel: ObservableObject {
     private var hasLoaded = false
     private let minimumClipDuration: Double = 10
     private let maximumClipDurationLimit: Double = 30
+    private let boundaryLoopDuration: Double = 2
 
     init(
         track: SpotifySimpleTrack,
@@ -187,8 +189,37 @@ final class AddSearchDetailViewModel: ObservableObject {
         endSeconds = clampedEnd
     }
 
+    var effectivePlaybackStartSeconds: Double {
+        boundaryLoopRange?.lowerBound ?? startSeconds
+    }
+
+    var effectivePlaybackEndSeconds: Double {
+        boundaryLoopRange?.upperBound ?? endSeconds
+    }
+
     func updatePlaybackSeconds(_ seconds: Double) {
         playbackSeconds = seconds
+    }
+
+    func activateBoundaryLoop(for control: AddSearchDetailTrimInteractionControl) {
+        guard hasPlayableVideo else { return }
+
+        switch control {
+        case .left:
+            let upperBound = min(startSeconds + boundaryLoopDuration, endSeconds)
+            guard upperBound > startSeconds else { return }
+            boundaryLoopRange = startSeconds...upperBound
+        case .right:
+            let lowerBound = max(endSeconds - boundaryLoopDuration, startSeconds)
+            guard endSeconds > lowerBound else { return }
+            boundaryLoopRange = lowerBound...endSeconds
+        default:
+            break
+        }
+    }
+
+    func deactivateBoundaryLoop() {
+        boundaryLoopRange = nil
     }
 
     func requestPlayback(from seconds: Double) {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -20,6 +20,10 @@ struct AddSearchDetailTrimSection: View {
                 .foregroundStyle(.white.opacity(0.9))
 
             if viewModel.hasPlayableVideo {
+                if viewModel.shouldShowBoundaryLoopHint {
+                    boundaryLoopHint
+                }
+
                 AddSearchDetailWaveformTrimView(
                     startSeconds: Binding(
                         get: { viewModel.startSeconds },
@@ -33,7 +37,10 @@ struct AddSearchDetailTrimSection: View {
                     playbackSeconds: viewModel.playbackSeconds,
                     startTimeText: startDisplayTimeText,
                     endTimeText: endDisplayTimeText,
-                    onTrimInteracted: onTrimInteracted,
+                    onTrimInteracted: {
+                        viewModel.dismissBoundaryLoopHint()
+                        onTrimInteracted()
+                    },
                     onInteractionEnded: onTrimInteractionEnded,
                     onUpdateRange: { start, end in
                         viewModel.updateRange(start: start, end: end)
@@ -82,5 +89,29 @@ struct AddSearchDetailTrimSection: View {
             }
         }
         .padding(AppSpacing.m)
+        .animation(.easeInOut(duration: 0.25), value: viewModel.shouldShowBoundaryLoopHint)
+    }
+
+    private var boundaryLoopHint: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "hand.tap.fill")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(AppColors.primary600)
+
+            Text("꾹 눌러서 시작과 끝 구간 반복이 가능해요!")
+                .font(AppFont.paperlogy4Regular(size: 12))
+                .foregroundStyle(.white.opacity(0.88))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            Capsule()
+                .fill(Color.white.opacity(0.07))
+        )
+        .overlay {
+            Capsule()
+                .stroke(AppColors.primary600.opacity(0.5), lineWidth: 1)
+        }
+        .transition(.opacity.combined(with: .scale(scale: 0.95)))
     }
 }

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -30,12 +30,16 @@ struct AddSearchDetailTrimSection: View {
                         set: { viewModel.updateEnd($0) }
                     ),
                     duration: viewModel.maxDuration,
+                    playbackSeconds: viewModel.playbackSeconds,
                     startTimeText: startDisplayTimeText,
                     endTimeText: endDisplayTimeText,
                     onTrimInteracted: onTrimInteracted,
                     onInteractionEnded: onTrimInteractionEnded,
                     onUpdateRange: { start, end in
                         viewModel.updateRange(start: start, end: end)
+                    },
+                    onSeekRequested: { seconds in
+                        viewModel.requestPlayback(from: seconds)
                     }
                 )
                 .frame(height: 160)

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -46,9 +46,12 @@ struct AddSearchDetailTrimSection: View {
                     },
                     onHandleLoopDeactivated: {
                         viewModel.deactivateBoundaryLoop()
+                    },
+                    onHandleDragMovementChanged: { isDragging in
+                        viewModel.setHandleDragging(isDragging)
                     }
                 )
-                .frame(height: 200)
+                .frame(height: 176)
 
                 HStack {
                     Text("선택 구간 \(startDisplayTimeText) ~ \(endDisplayTimeText)")

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -55,12 +55,13 @@ struct AddSearchDetailTrimSection: View {
                         viewModel.setHandleDragging(isDragging)
                     }
                 )
-                .frame(height: 176)
+                .frame(height: 186)
 
                 HStack {
                     Text("선택 구간 \(startDisplayTimeText) ~ \(endDisplayTimeText)")
                         .font(AppFont.paperlogy5Medium(size: 13))
                         .foregroundStyle(AppColors.primary600)
+                        .contentTransition(.identity)
 
                     Spacer()
 

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -40,9 +40,15 @@ struct AddSearchDetailTrimSection: View {
                     },
                     onSeekRequested: { seconds in
                         viewModel.requestPlayback(from: seconds)
+                    },
+                    onHandleLoopActivated: { control in
+                        viewModel.activateBoundaryLoop(for: control)
+                    },
+                    onHandleLoopDeactivated: {
+                        viewModel.deactivateBoundaryLoop()
                     }
                 )
-                .frame(height: 160)
+                .frame(height: 200)
 
                 HStack {
                     Text("선택 구간 \(startDisplayTimeText) ~ \(endDisplayTimeText)")

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailTrimSection.swift
@@ -37,10 +37,7 @@ struct AddSearchDetailTrimSection: View {
                     playbackSeconds: viewModel.playbackSeconds,
                     startTimeText: startDisplayTimeText,
                     endTimeText: endDisplayTimeText,
-                    onTrimInteracted: {
-                        viewModel.dismissBoundaryLoopHint()
-                        onTrimInteracted()
-                    },
+                    onTrimInteracted: onTrimInteracted,
                     onInteractionEnded: onTrimInteractionEnded,
                     onUpdateRange: { start, end in
                         viewModel.updateRange(start: start, end: end)
@@ -101,6 +98,17 @@ struct AddSearchDetailTrimSection: View {
             Text("꾹 눌러서 시작과 끝 구간 반복이 가능해요!")
                 .font(AppFont.paperlogy4Regular(size: 12))
                 .foregroundStyle(.white.opacity(0.88))
+
+            Button {
+                viewModel.dismissBoundaryLoopHint()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.6))
+                    .padding(4)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
@@ -16,8 +16,8 @@ struct AddSearchDetailVideoSection: View {
                     VStack(alignment: .leading, spacing: AppSpacing.s) {
                         YoutubePlayerView(
                             videoURL: video.embedURL,
-                            startSeconds: viewModel.startSeconds,
-                            endSeconds: viewModel.endSeconds,
+                            startSeconds: viewModel.effectivePlaybackStartSeconds,
+                            endSeconds: viewModel.effectivePlaybackEndSeconds,
                             playbackFocusToken: playerReloadToken.hashValue,
                             seekSeconds: viewModel.playbackSeekRequest?.seconds,
                             seekToken: viewModel.playbackSeekRequest?.token ?? 0,

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
@@ -18,7 +18,12 @@ struct AddSearchDetailVideoSection: View {
                             videoURL: video.embedURL,
                             startSeconds: viewModel.startSeconds,
                             endSeconds: viewModel.endSeconds,
-                            playbackFocusToken: playerReloadToken.hashValue
+                            playbackFocusToken: playerReloadToken.hashValue,
+                            seekSeconds: viewModel.playbackSeekRequest?.seconds,
+                            seekToken: viewModel.playbackSeekRequest?.token ?? 0,
+                            onPlaybackProgressChanged: { progress in
+                                viewModel.updatePlaybackSeconds(progress.currentSeconds)
+                            }
                         )
                             .id(playerReloadToken)
                             .frame(maxWidth: .infinity)

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailVideoSection.swift
@@ -18,6 +18,7 @@ struct AddSearchDetailVideoSection: View {
                             videoURL: video.embedURL,
                             startSeconds: viewModel.effectivePlaybackStartSeconds,
                             endSeconds: viewModel.effectivePlaybackEndSeconds,
+                            isPlaying: !viewModel.isHandleDragging,
                             playbackFocusToken: playerReloadToken.hashValue,
                             seekSeconds: viewModel.playbackSeekRequest?.seconds,
                             seekToken: viewModel.playbackSeekRequest?.token ?? 0,

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -20,6 +20,8 @@ struct AddSearchDetailWaveformTrimView: View {
     let onInteractionEnded: (_ control: AddSearchDetailTrimInteractionControl) -> Void
     let onUpdateRange: (_ start: Double, _ end: Double) -> Void
     let onSeekRequested: (_ seconds: Double) -> Void
+    let onHandleLoopActivated: (_ control: AddSearchDetailTrimInteractionControl) -> Void
+    let onHandleLoopDeactivated: () -> Void
 
     private let horizontalPadding: CGFloat = 18
     private let pointsPerSecond: CGFloat = 8
@@ -30,8 +32,11 @@ struct AddSearchDetailWaveformTrimView: View {
     private let overviewHorizontalInset: CGFloat = 8
     private let barWidth: CGFloat = 4
     private let barSpacing: CGFloat = 3
-    private let handleWidth: CGFloat = 34
+    private let handleWidth: CGFloat = 20
     private let handleCornerRadius: CGFloat = 14
+    private let handleBodyCornerRadius: CGFloat = 7
+    private let handleVerticalInset: CGFloat = 4
+    private let handleEdgeInset: CGFloat = 3
     private let autoScrollEdgeThreshold: CGFloat = 52
     private let autoScrollMaxVelocity: CGFloat = 260
     private let followButtonSize: CGFloat = 30
@@ -43,6 +48,9 @@ struct AddSearchDetailWaveformTrimView: View {
     private let maximumClipDuration: Double = 30
     private let handlePressedScale: CGFloat = 1.12
     private let selectionRecenterDelay: TimeInterval = 0.4
+    private let handleLoopActivationDelay: TimeInterval = 0.5
+    private let boundaryLoopDuration: Double = 2
+    private let nudgeAnimation = Animation.spring(response: 0.3, dampingFraction: 0.85)
     private let offscreenFollowThreshold: CGFloat = 6
     private let timelineCoordinateSpaceName = "addSearchDetailTimeline"
 
@@ -61,6 +69,8 @@ struct AddSearchDetailWaveformTrimView: View {
     @State private var timelineContentWidth: CGFloat = 0
     @State private var timelineScrollEndWorkItem: DispatchWorkItem?
     @State private var selectionRecenterWorkItem: DispatchWorkItem?
+    @State private var handleLoopWorkItem: DispatchWorkItem?
+    @State private var activeLoopDirection: HandleDirection?
 
     var body: some View {
         GeometryReader { proxy in
@@ -100,12 +110,13 @@ struct AddSearchDetailWaveformTrimView: View {
                         timelineContentWidth = scrollView.contentSize.width
                     }
                 }
-                .overlay(alignment: .bottomLeading) {
+                HStack {
                     secondNudgeButton(title: "-1s") {
                         nudgeSelection(by: -1)
                     }
-                }
-                .overlay(alignment: .bottomTrailing) {
+
+                    Spacer()
+
                     secondNudgeButton(title: "+1s") {
                         nudgeSelection(by: 1)
                     }
@@ -120,6 +131,7 @@ struct AddSearchDetailWaveformTrimView: View {
             timelineScrollEndWorkItem = nil
             selectionRecenterWorkItem?.cancel()
             selectionRecenterWorkItem = nil
+            cancelHandleLoop()
         }
     }
 
@@ -171,6 +183,28 @@ struct AddSearchDetailWaveformTrimView: View {
                 .allowsHitTesting(false)
                 .zIndex(2)
 
+            if let loopDirection = activeLoopDirection {
+                let innerStartX = startX + handleEdgeInset + handleWidth
+                let innerEndX = endX - handleEdgeInset - handleWidth
+                let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
+                let rawLoopWidth = duration > 0
+                    ? CGFloat(boundaryLoopDuration / duration) * usableWidth
+                    : 0
+                let loopWidth = min(rawLoopWidth, max(innerEndX - innerStartX, 0))
+
+                if loopWidth > 0 {
+                    let bandStartX = loopDirection == .left ? innerStartX : innerEndX - loopWidth
+
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(AppColors.primary600.opacity(0.32))
+                        .frame(width: loopWidth, height: trackHeight - handleVerticalInset * 2)
+                        .position(x: bandStartX + loopWidth / 2, y: trackHeight / 2)
+                        .allowsHitTesting(false)
+                        .transition(.opacity)
+                        .zIndex(2)
+                }
+            }
+
             if let playheadX {
                 RoundedRectangle(cornerRadius: playheadWidth / 2)
                     .fill(Color.white)
@@ -188,7 +222,10 @@ struct AddSearchDetailWaveformTrimView: View {
                     .spring(response: 0.28, dampingFraction: 0.7),
                     value: activeHandleDragDirection == .left
                 )
-                .position(x: startX + handleWidth / 2, y: trackHeight / 2)
+                .position(
+                    x: startX + handleEdgeInset + handleWidth / 2,
+                    y: trackHeight / 2
+                )
                 .highPriorityGesture(
                     startHandleDragGesture(
                         contentWidth: contentWidth,
@@ -203,7 +240,10 @@ struct AddSearchDetailWaveformTrimView: View {
                     .spring(response: 0.28, dampingFraction: 0.7),
                     value: activeHandleDragDirection == .right
                 )
-                .position(x: endX - handleWidth / 2, y: trackHeight / 2)
+                .position(
+                    x: endX - handleEdgeInset - handleWidth / 2,
+                    y: trackHeight / 2
+                )
                 .highPriorityGesture(
                     endHandleDragGesture(
                         contentWidth: contentWidth,
@@ -267,8 +307,8 @@ struct AddSearchDetailWaveformTrimView: View {
             return nil
         }
 
-        let innerStartX = startX + handleWidth + playheadWidth / 2
-        let innerEndX = endX - handleWidth - playheadWidth / 2
+        let innerStartX = startX + handleEdgeInset + handleWidth + playheadWidth / 2
+        let innerEndX = endX - handleEdgeInset - handleWidth - playheadWidth / 2
         guard innerEndX > innerStartX else { return nil }
 
         let clipDuration = max(endSeconds - startSeconds, 0.0001)
@@ -430,31 +470,19 @@ struct AddSearchDetailWaveformTrimView: View {
     }
 
     private func trimHandle(direction: HandleDirection) -> some View {
-        let roundedSide: AddSearchDetailHandleRoundedSide = direction == .left ? .left : .right
-
-        return ZStack {
-            Rectangle()
+        ZStack {
+            RoundedRectangle(cornerRadius: handleBodyCornerRadius)
                 .fill(AppColors.primary600)
 
             Image(systemName: direction.systemSymbolName)
-                .font(.system(size: 16, weight: .black, design: .rounded))
+                .font(.system(size: 12, weight: .black, design: .rounded))
                 .foregroundStyle(.black.opacity(0.92))
         }
-        .frame(width: handleWidth, height: trackHeight)
-        .clipShape(
-            AddSearchDetailHandleShape(
-                roundedSide: roundedSide,
-                radius: handleCornerRadius
-            )
-        )
-        .overlay {
-            AddSearchDetailHandleShape(
-                roundedSide: roundedSide,
-                radius: handleCornerRadius
-            )
-            .stroke(Color.white.opacity(0.82), lineWidth: 1)
-        }
+        .frame(width: handleWidth, height: trackHeight - handleVerticalInset * 2)
         .shadow(color: .black.opacity(0.35), radius: 5, x: 0, y: 2)
+        .padding(.horizontal, 8)
+        .padding(.vertical, handleVerticalInset)
+        .contentShape(Rectangle())
     }
 
     private func secondNudgeButton(title: String, action: @escaping () -> Void) -> some View {
@@ -491,11 +519,17 @@ struct AddSearchDetailWaveformTrimView: View {
                 newStart = max(duration - clipDuration, 0)
             }
 
-            onUpdateRange(newStart, newEnd)
+            withAnimation(nudgeAnimation) {
+                onUpdateRange(newStart, newEnd)
+            }
         } else if delta < 0 {
-            startSeconds += delta
+            withAnimation(nudgeAnimation) {
+                startSeconds += delta
+            }
         } else {
-            endSeconds += delta
+            withAnimation(nudgeAnimation) {
+                endSeconds += delta
+            }
         }
 
         onInteractionEnded(delta < 0 ? .minusOneSecond : .plusOneSecond)
@@ -596,20 +630,27 @@ struct AddSearchDetailWaveformTrimView: View {
                 if startDragBase == nil {
                     startDragBase = startSeconds
                     onTrimInteracted()
+                    scheduleHandleLoopActivation(direction: .left)
                 }
                 activateDrag(direction: .left, contentWidth: contentWidth)
                 activeHandleDragTranslation = value.translation.width
+                if isBeyondTapThreshold(value.translation) {
+                    cancelHandleLoop()
+                }
                 updateAutoScrollVelocity(locationX: value.location.x, viewportWidth: viewportWidth)
                 applyActiveHandleDrag()
             }
             .onEnded { value in
-                let isTap = abs(value.translation.width) < handleTapMaxTranslation
-                    && abs(value.translation.height) < handleTapMaxTranslation
+                let didActivateLoop = activeLoopDirection == .left
+                let isTap = !isBeyondTapThreshold(value.translation)
+                cancelHandleLoop()
                 startDragBase = nil
                 onInteractionEnded(.left)
                 endActiveHandleDrag()
                 if isTap {
-                    onSeekRequested(startSeconds)
+                    if !didActivateLoop {
+                        onSeekRequested(startSeconds)
+                    }
                 } else {
                     scheduleSelectionRecenter()
                 }
@@ -622,18 +663,58 @@ struct AddSearchDetailWaveformTrimView: View {
                 if endDragBase == nil {
                     endDragBase = endSeconds
                     onTrimInteracted()
+                    scheduleHandleLoopActivation(direction: .right)
                 }
                 activateDrag(direction: .right, contentWidth: contentWidth)
                 activeHandleDragTranslation = value.translation.width
+                if isBeyondTapThreshold(value.translation) {
+                    cancelHandleLoop()
+                }
                 updateAutoScrollVelocity(locationX: value.location.x, viewportWidth: viewportWidth)
                 applyActiveHandleDrag()
             }
-            .onEnded { _ in
+            .onEnded { value in
+                cancelHandleLoop()
                 endDragBase = nil
                 onInteractionEnded(.right)
                 endActiveHandleDrag()
-                scheduleSelectionRecenter()
+                if isBeyondTapThreshold(value.translation) {
+                    scheduleSelectionRecenter()
+                }
             }
+    }
+
+    private func isBeyondTapThreshold(_ translation: CGSize) -> Bool {
+        abs(translation.width) >= handleTapMaxTranslation
+            || abs(translation.height) >= handleTapMaxTranslation
+    }
+
+    private func scheduleHandleLoopActivation(direction: HandleDirection) {
+        handleLoopWorkItem?.cancel()
+        let workItem = DispatchWorkItem {
+            guard activeHandleDragDirection == direction else { return }
+            guard abs(activeHandleDragTranslation) < handleTapMaxTranslation else { return }
+            withAnimation(.easeInOut(duration: 0.2)) {
+                activeLoopDirection = direction
+            }
+            onHandleLoopActivated(direction == .left ? .left : .right)
+        }
+        handleLoopWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + handleLoopActivationDelay,
+            execute: workItem
+        )
+    }
+
+    private func cancelHandleLoop() {
+        handleLoopWorkItem?.cancel()
+        handleLoopWorkItem = nil
+        if activeLoopDirection != nil {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                activeLoopDirection = nil
+            }
+            onHandleLoopDeactivated()
+        }
     }
 
     private func activateDrag(direction: HandleDirection, contentWidth: CGFloat) {
@@ -893,11 +974,6 @@ struct AddSearchDetailWaveformTrimView: View {
     }
 }
 
-private enum AddSearchDetailHandleRoundedSide {
-    case left
-    case right
-}
-
 private struct AddSearchDetailTimelineViewport {
     let contentOffsetX: CGFloat
     let viewportWidth: CGFloat
@@ -1024,24 +1100,3 @@ private struct AddSearchDetailScrollViewResolver: UIViewRepresentable {
     }
 }
 
-private struct AddSearchDetailHandleShape: Shape {
-    let roundedSide: AddSearchDetailHandleRoundedSide
-    let radius: CGFloat
-
-    func path(in rect: CGRect) -> Path {
-        let corners: UIRectCorner
-        switch roundedSide {
-        case .left:
-            corners = [.topLeft, .bottomLeft]
-        case .right:
-            corners = [.topRight, .bottomRight]
-        }
-
-        let bezierPath = UIBezierPath(
-            roundedRect: rect,
-            byRoundingCorners: corners,
-            cornerRadii: CGSize(width: radius, height: radius)
-        )
-        return Path(bezierPath.cgPath)
-    }
-}

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -37,7 +37,7 @@ struct AddSearchDetailWaveformTrimView: View {
     private let handleCornerRadius: CGFloat = 14
     private let handleBodyCornerRadius: CGFloat = 7
     private let handleVerticalInset: CGFloat = 8
-    private let handleEdgeInset: CGFloat = 3
+    private let handleEdgeInset: CGFloat = 0
     private let autoScrollEdgeThreshold: CGFloat = 52
     private let autoScrollMaxVelocity: CGFloat = 260
     private let followButtonSize: CGFloat = 30
@@ -451,6 +451,7 @@ struct AddSearchDetailWaveformTrimView: View {
                 }
                 .onEnded { _ in
                     onInteractionEnded(.spectrumBar)
+                    scrollTimelineToCenterSelection(animated: true)
                 }
         )
     }
@@ -813,10 +814,14 @@ struct AddSearchDetailWaveformTrimView: View {
     }
 
     private func scrollTimelineToCenterSelection(animated: Bool) {
+        scrollTimelineToCenter(start: startSeconds, end: endSeconds, animated: animated)
+    }
+
+    private func scrollTimelineToCenter(start: Double, end: Double, animated: Bool) {
         guard let scrollView = timelineScrollView else { return }
         let contentWidth = resolvedTimelineContentWidth(for: scrollView)
-        let startX = xPosition(for: startSeconds, contentWidth: contentWidth)
-        let endX = xPosition(for: endSeconds, contentWidth: contentWidth)
+        let startX = xPosition(for: start, contentWidth: contentWidth)
+        let endX = xPosition(for: end, contentWidth: contentWidth)
         let offsetX = (startX + endX) / 2 - scrollView.bounds.width / 2
         setTimelineOffset(offsetX, in: scrollView, animated: animated)
     }
@@ -991,7 +996,7 @@ struct AddSearchDetailWaveformTrimView: View {
         }
 
         onUpdateRange(newStart, newEnd)
-        scrollTimelineToStart(newStart, animated: false)
+        scrollTimelineToCenter(start: newStart, end: newEnd, animated: false)
     }
 
     private func scrollTimelineToStart(_ seconds: Double, animated: Bool) {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -5,17 +5,21 @@ enum AddSearchDetailTrimInteractionControl: String {
     case left
     case right
     case spectrumBar = "spectrum_bar"
+    case minusOneSecond = "minus_1s"
+    case plusOneSecond = "plus_1s"
 }
 
 struct AddSearchDetailWaveformTrimView: View {
     @Binding var startSeconds: Double
     @Binding var endSeconds: Double
     let duration: Double
+    let playbackSeconds: Double
     let startTimeText: String
     let endTimeText: String
     let onTrimInteracted: () -> Void
     let onInteractionEnded: (_ control: AddSearchDetailTrimInteractionControl) -> Void
     let onUpdateRange: (_ start: Double, _ end: Double) -> Void
+    let onSeekRequested: (_ seconds: Double) -> Void
 
     private let horizontalPadding: CGFloat = 18
     private let pointsPerSecond: CGFloat = 8
@@ -32,6 +36,10 @@ struct AddSearchDetailWaveformTrimView: View {
     private let autoScrollMaxVelocity: CGFloat = 260
     private let followButtonSize: CGFloat = 30
     private let followButtonInset: CGFloat = 10
+    private let nudgeButtonSize: CGFloat = 30
+    private let playheadWidth: CGFloat = 3
+    private let handleTapMaxTranslation: CGFloat = 4
+    private let selectionBorderLineWidth: CGFloat = 1.5
     private let offscreenFollowThreshold: CGFloat = 6
     private let timelineCoordinateSpaceName = "addSearchDetailTimeline"
 
@@ -88,6 +96,16 @@ struct AddSearchDetailWaveformTrimView: View {
                         timelineContentWidth = scrollView.contentSize.width
                     }
                 }
+                .overlay(alignment: .bottomLeading) {
+                    secondNudgeButton(title: "-1s") {
+                        nudgeSelection(by: -1)
+                    }
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    secondNudgeButton(title: "+1s") {
+                        nudgeSelection(by: 1)
+                    }
+                }
 
                 overviewBar(width: viewportWidth)
             }
@@ -104,6 +122,7 @@ struct AddSearchDetailWaveformTrimView: View {
         let endX = xPosition(for: endSeconds, contentWidth: contentWidth)
         let selectedWidth = max(endX - startX, 1)
         let trailingWidth = max(contentWidth - endX, 0)
+        let playheadX = playheadXPosition(startX: startX, endX: endX, contentWidth: contentWidth)
         let visibleRange = timelineVisibleRange(
             contentWidth: contentWidth,
             fallbackViewportWidth: viewportWidth
@@ -112,8 +131,13 @@ struct AddSearchDetailWaveformTrimView: View {
         let isEndOffscreen = endX > visibleRange.upperBound + offscreenFollowThreshold
 
         return ZStack(alignment: .leading) {
-            waveformBars(contentWidth: contentWidth)
-                .zIndex(0)
+            waveformBars(
+                contentWidth: contentWidth,
+                startX: startX,
+                endX: endX,
+                playheadX: playheadX
+            )
+            .zIndex(0)
 
             HStack(spacing: 0) {
                 Rectangle()
@@ -121,7 +145,7 @@ struct AddSearchDetailWaveformTrimView: View {
                     .frame(width: max(startX, 0))
 
                 Rectangle()
-                    .fill(AppColors.primary600.opacity(0.25))
+                    .fill(Color.clear)
                     .frame(width: selectedWidth)
 
                 Rectangle()
@@ -130,6 +154,27 @@ struct AddSearchDetailWaveformTrimView: View {
             }
             .allowsHitTesting(false)
             .zIndex(1)
+
+            RoundedRectangle(cornerRadius: handleCornerRadius)
+                .stroke(AppColors.primary600, lineWidth: selectionBorderLineWidth)
+                .frame(
+                    width: max(endX - startX + handleWidth, handleWidth),
+                    height: trackHeight - selectionBorderLineWidth
+                )
+                .position(x: (startX + endX) / 2, y: trackHeight / 2)
+                .allowsHitTesting(false)
+                .zIndex(2)
+
+            if let playheadX {
+                RoundedRectangle(cornerRadius: playheadWidth / 2)
+                    .fill(Color.white)
+                    .frame(width: playheadWidth, height: trackHeight - 10)
+                    .shadow(color: .black.opacity(0.4), radius: 2, x: 0, y: 0)
+                    .position(x: playheadX, y: trackHeight / 2)
+                    .animation(.linear(duration: 0.25), value: playheadX)
+                    .allowsHitTesting(false)
+                    .zIndex(3)
+            }
 
             trimHandle(direction: .left)
                 .position(x: startX, y: trackHeight / 2)
@@ -186,6 +231,33 @@ struct AddSearchDetailWaveformTrimView: View {
                 .stroke(Color.white.opacity(0.1), lineWidth: 1)
         }
         .clipShape(RoundedRectangle(cornerRadius: 16))
+        .contentShape(Rectangle())
+        .onTapGesture { location in
+            onTrimInteracted()
+            onSeekRequested(timeForContentX(location.x, contentWidth: contentWidth))
+        }
+    }
+
+    private func playheadXPosition(
+        startX: CGFloat,
+        endX: CGFloat,
+        contentWidth: CGFloat
+    ) -> CGFloat? {
+        guard
+            duration > 0,
+            playbackSeconds >= startSeconds - 0.2,
+            playbackSeconds <= endSeconds + 0.2
+        else {
+            return nil
+        }
+
+        let innerStartX = startX + handleWidth / 2 + playheadWidth / 2
+        let innerEndX = endX - handleWidth / 2 - playheadWidth / 2
+        guard innerEndX > innerStartX else { return nil }
+
+        let clipDuration = max(endSeconds - startSeconds, 0.0001)
+        let ratio = min(max((playbackSeconds - startSeconds) / clipDuration, 0), 1)
+        return innerStartX + CGFloat(ratio) * (innerEndX - innerStartX)
     }
 
     private func handleTimeLabels(contentWidth: CGFloat) -> some View {
@@ -292,20 +364,53 @@ struct AddSearchDetailWaveformTrimView: View {
         .frame(width: width, height: overviewHeight - 4, alignment: .leading)
     }
 
-    private func waveformBars(contentWidth: CGFloat) -> some View {
+    private func waveformBars(
+        contentWidth: CGFloat,
+        startX: CGFloat,
+        endX: CGFloat,
+        playheadX: CGFloat?
+    ) -> some View {
         let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
         let totalBarWidth = barWidth + barSpacing
         let barCount = max(Int(usableWidth / totalBarWidth), 1)
 
         return HStack(alignment: .center, spacing: barSpacing) {
             ForEach(0..<barCount, id: \.self) { index in
+                let barCenterX = horizontalPadding + CGFloat(index) * totalBarWidth + barWidth / 2
+
                 Capsule()
-                    .fill(Color.white.opacity(barOpacity(for: index)))
+                    .fill(
+                        barColor(
+                            centerX: barCenterX,
+                            index: index,
+                            startX: startX,
+                            endX: endX,
+                            playheadX: playheadX
+                        )
+                    )
                     .frame(width: barWidth, height: barHeight(for: index))
             }
         }
         .frame(width: usableWidth, height: trackHeight, alignment: .leading)
         .padding(.horizontal, horizontalPadding)
+    }
+
+    private func barColor(
+        centerX: CGFloat,
+        index: Int,
+        startX: CGFloat,
+        endX: CGFloat,
+        playheadX: CGFloat?
+    ) -> Color {
+        guard centerX >= startX, centerX <= endX else {
+            return Color.white.opacity(barOpacity(for: index))
+        }
+
+        if let playheadX, centerX <= playheadX {
+            return AppColors.primary600
+        }
+
+        return Color.white.opacity(0.95)
     }
 
     private func trimHandle(direction: HandleDirection) -> some View {
@@ -334,6 +439,42 @@ struct AddSearchDetailWaveformTrimView: View {
             .stroke(Color.white.opacity(0.82), lineWidth: 1)
         }
         .shadow(color: .black.opacity(0.35), radius: 5, x: 0, y: 2)
+    }
+
+    private func secondNudgeButton(title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(AppFont.paperlogy6SemiBold(size: 11))
+                .foregroundStyle(.black.opacity(0.92))
+                .frame(width: nudgeButtonSize, height: nudgeButtonSize)
+                .background(
+                    Circle()
+                        .fill(AppColors.primary600)
+                )
+                .shadow(color: .black.opacity(0.35), radius: 4, x: 0, y: 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func nudgeSelection(by delta: Double) {
+        guard duration > 0 else { return }
+
+        onTrimInteracted()
+        let clipDuration = min(max(currentClipDuration, 1), duration)
+        var newStart = startSeconds + delta
+        var newEnd = newStart + clipDuration
+
+        if newStart < 0 {
+            newStart = 0
+            newEnd = clipDuration
+        }
+        if newEnd > duration {
+            newEnd = duration
+            newStart = max(duration - clipDuration, 0)
+        }
+
+        onUpdateRange(newStart, newEnd)
+        onInteractionEnded(delta < 0 ? .minusOneSecond : .plusOneSecond)
     }
 
     private func followScrollButton(direction: HandleDirection) -> some View {
@@ -436,10 +577,15 @@ struct AddSearchDetailWaveformTrimView: View {
                 updateAutoScrollVelocity(locationX: value.location.x, viewportWidth: viewportWidth)
                 applyActiveHandleDrag()
             }
-            .onEnded { _ in
+            .onEnded { value in
+                let isTap = abs(value.translation.width) < handleTapMaxTranslation
+                    && abs(value.translation.height) < handleTapMaxTranslation
                 startDragBase = nil
                 onInteractionEnded(.left)
                 endActiveHandleDrag()
+                if isTap {
+                    onSeekRequested(startSeconds)
+                }
             }
     }
 
@@ -608,6 +754,13 @@ struct AddSearchDetailWaveformTrimView: View {
 
     private var currentClipDuration: Double {
         max(endSeconds - startSeconds, 0)
+    }
+
+    private func timeForContentX(_ x: CGFloat, contentWidth: CGFloat) -> Double {
+        guard duration > 0 else { return 0 }
+        let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
+        let clamped = min(max(x - horizontalPadding, 0), usableWidth)
+        return Double(clamped / usableWidth) * duration
     }
 
     private func timeForOverviewX(_ x: CGFloat, width: CGFloat) -> Double {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -769,6 +769,9 @@ struct AddSearchDetailWaveformTrimView: View {
                 activeLoopDirection = direction
             }
             onHandleLoopActivated(direction == .left ? .left : .right)
+            stopAutoScrollTimer()
+            timelineScrollView?.isScrollEnabled = false
+            scrollTimelineToCenterSelection(animated: true)
         }
         handleLoopWorkItem = workItem
         DispatchQueue.main.asyncAfter(
@@ -784,6 +787,7 @@ struct AddSearchDetailWaveformTrimView: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 activeLoopDirection = nil
             }
+            timelineScrollView?.isScrollEnabled = true
             onHandleLoopDeactivated()
         }
     }
@@ -849,6 +853,11 @@ struct AddSearchDetailWaveformTrimView: View {
     }
 
     private func updateAutoScrollVelocity(locationX: CGFloat, viewportWidth: CGFloat) {
+        guard activeLoopDirection == nil else {
+            stopAutoScrollTimer()
+            return
+        }
+
         autoScrollVelocity = autoScrollVelocityForEdge(
             locationX: locationX,
             viewportWidth: viewportWidth

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -22,10 +22,11 @@ struct AddSearchDetailWaveformTrimView: View {
     let onSeekRequested: (_ seconds: Double) -> Void
     let onHandleLoopActivated: (_ control: AddSearchDetailTrimInteractionControl) -> Void
     let onHandleLoopDeactivated: () -> Void
+    let onHandleDragMovementChanged: (_ isDragging: Bool) -> Void
 
     private let horizontalPadding: CGFloat = 18
     private let pointsPerSecond: CGFloat = 8
-    private let trackHeight: CGFloat = 104
+    private let trackHeight: CGFloat = 84
     private let handleLabelHeight: CGFloat = 18
     private let handleLabelWidth: CGFloat = 76
     private let overviewHeight: CGFloat = 24
@@ -35,7 +36,7 @@ struct AddSearchDetailWaveformTrimView: View {
     private let handleWidth: CGFloat = 20
     private let handleCornerRadius: CGFloat = 14
     private let handleBodyCornerRadius: CGFloat = 7
-    private let handleVerticalInset: CGFloat = 4
+    private let handleVerticalInset: CGFloat = 8
     private let handleEdgeInset: CGFloat = 3
     private let autoScrollEdgeThreshold: CGFloat = 52
     private let autoScrollMaxVelocity: CGFloat = 260
@@ -132,6 +133,7 @@ struct AddSearchDetailWaveformTrimView: View {
             selectionRecenterWorkItem?.cancel()
             selectionRecenterWorkItem = nil
             cancelHandleLoop()
+            onHandleDragMovementChanged(false)
         }
     }
 
@@ -148,12 +150,31 @@ struct AddSearchDetailWaveformTrimView: View {
         let isStartOffscreen = startX < visibleRange.lowerBound - offscreenFollowThreshold
         let isEndOffscreen = endX > visibleRange.upperBound + offscreenFollowThreshold
 
+        let loopBandRange = loopBandXRange(startX: startX, endX: endX, contentWidth: contentWidth)
+
         return ZStack(alignment: .leading) {
+            if let loopBandRange {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(AppColors.primary600.opacity(0.9))
+                    .frame(
+                        width: loopBandRange.upperBound - loopBandRange.lowerBound,
+                        height: trackHeight - handleVerticalInset * 2
+                    )
+                    .position(
+                        x: (loopBandRange.lowerBound + loopBandRange.upperBound) / 2,
+                        y: trackHeight / 2
+                    )
+                    .allowsHitTesting(false)
+                    .transition(.opacity)
+                    .zIndex(0)
+            }
+
             waveformBars(
                 contentWidth: contentWidth,
                 startX: startX,
                 endX: endX,
-                playheadX: playheadX
+                playheadX: playheadX,
+                loopBandRange: loopBandRange
             )
             .zIndex(0)
 
@@ -182,28 +203,6 @@ struct AddSearchDetailWaveformTrimView: View {
                 .position(x: (startX + endX) / 2, y: trackHeight / 2)
                 .allowsHitTesting(false)
                 .zIndex(2)
-
-            if let loopDirection = activeLoopDirection {
-                let innerStartX = startX + handleEdgeInset + handleWidth
-                let innerEndX = endX - handleEdgeInset - handleWidth
-                let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
-                let rawLoopWidth = duration > 0
-                    ? CGFloat(boundaryLoopDuration / duration) * usableWidth
-                    : 0
-                let loopWidth = min(rawLoopWidth, max(innerEndX - innerStartX, 0))
-
-                if loopWidth > 0 {
-                    let bandStartX = loopDirection == .left ? innerStartX : innerEndX - loopWidth
-
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill(AppColors.primary600.opacity(0.32))
-                        .frame(width: loopWidth, height: trackHeight - handleVerticalInset * 2)
-                        .position(x: bandStartX + loopWidth / 2, y: trackHeight / 2)
-                        .allowsHitTesting(false)
-                        .transition(.opacity)
-                        .zIndex(2)
-                }
-            }
 
             if let playheadX {
                 RoundedRectangle(cornerRadius: playheadWidth / 2)
@@ -292,6 +291,24 @@ struct AddSearchDetailWaveformTrimView: View {
             onTrimInteracted()
             onSeekRequested(timeForContentX(location.x, contentWidth: contentWidth))
         }
+    }
+
+    private func loopBandXRange(
+        startX: CGFloat,
+        endX: CGFloat,
+        contentWidth: CGFloat
+    ) -> ClosedRange<CGFloat>? {
+        guard let loopDirection = activeLoopDirection, duration > 0 else { return nil }
+
+        let innerStartX = startX + handleEdgeInset + handleWidth
+        let innerEndX = endX - handleEdgeInset - handleWidth
+        let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
+        let rawLoopWidth = CGFloat(boundaryLoopDuration / duration) * usableWidth
+        let loopWidth = min(rawLoopWidth, max(innerEndX - innerStartX, 0))
+        guard loopWidth > 0 else { return nil }
+
+        let bandStartX = loopDirection == .left ? innerStartX : innerEndX - loopWidth
+        return bandStartX...(bandStartX + loopWidth)
     }
 
     private func playheadXPosition(
@@ -424,7 +441,8 @@ struct AddSearchDetailWaveformTrimView: View {
         contentWidth: CGFloat,
         startX: CGFloat,
         endX: CGFloat,
-        playheadX: CGFloat?
+        playheadX: CGFloat?,
+        loopBandRange: ClosedRange<CGFloat>?
     ) -> some View {
         let usableWidth = max(contentWidth - horizontalPadding * 2, 1)
         let totalBarWidth = barWidth + barSpacing
@@ -441,7 +459,8 @@ struct AddSearchDetailWaveformTrimView: View {
                             index: index,
                             startX: startX,
                             endX: endX,
-                            playheadX: playheadX
+                            playheadX: playheadX,
+                            loopBandRange: loopBandRange
                         )
                     )
                     .frame(width: barWidth, height: barHeight(for: index))
@@ -456,10 +475,15 @@ struct AddSearchDetailWaveformTrimView: View {
         index: Int,
         startX: CGFloat,
         endX: CGFloat,
-        playheadX: CGFloat?
+        playheadX: CGFloat?,
+        loopBandRange: ClosedRange<CGFloat>?
     ) -> Color {
         guard centerX >= startX, centerX <= endX else {
             return Color.white.opacity(barOpacity(for: index))
+        }
+
+        if let loopBandRange, loopBandRange.contains(centerX) {
+            return Color.black.opacity(0.82)
         }
 
         if let playheadX, centerX <= playheadX {
@@ -636,6 +660,7 @@ struct AddSearchDetailWaveformTrimView: View {
                 activeHandleDragTranslation = value.translation.width
                 if isBeyondTapThreshold(value.translation) {
                     cancelHandleLoop()
+                    onHandleDragMovementChanged(true)
                 }
                 updateAutoScrollVelocity(locationX: value.location.x, viewportWidth: viewportWidth)
                 applyActiveHandleDrag()
@@ -644,6 +669,7 @@ struct AddSearchDetailWaveformTrimView: View {
                 let didActivateLoop = activeLoopDirection == .left
                 let isTap = !isBeyondTapThreshold(value.translation)
                 cancelHandleLoop()
+                onHandleDragMovementChanged(false)
                 startDragBase = nil
                 onInteractionEnded(.left)
                 endActiveHandleDrag()
@@ -669,12 +695,14 @@ struct AddSearchDetailWaveformTrimView: View {
                 activeHandleDragTranslation = value.translation.width
                 if isBeyondTapThreshold(value.translation) {
                     cancelHandleLoop()
+                    onHandleDragMovementChanged(true)
                 }
                 updateAutoScrollVelocity(locationX: value.location.x, viewportWidth: viewportWidth)
                 applyActiveHandleDrag()
             }
             .onEnded { value in
                 cancelHandleLoop()
+                onHandleDragMovementChanged(false)
                 endDragBase = nil
                 onInteractionEnded(.right)
                 endActiveHandleDrag()

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -40,6 +40,9 @@ struct AddSearchDetailWaveformTrimView: View {
     private let playheadWidth: CGFloat = 3
     private let handleTapMaxTranslation: CGFloat = 4
     private let selectionBorderLineWidth: CGFloat = 1.5
+    private let maximumClipDuration: Double = 30
+    private let handlePressedScale: CGFloat = 1.12
+    private let selectionRecenterDelay: TimeInterval = 0.4
     private let offscreenFollowThreshold: CGFloat = 6
     private let timelineCoordinateSpaceName = "addSearchDetailTimeline"
 
@@ -57,6 +60,7 @@ struct AddSearchDetailWaveformTrimView: View {
     @State private var timelineViewportWidth: CGFloat = 0
     @State private var timelineContentWidth: CGFloat = 0
     @State private var timelineScrollEndWorkItem: DispatchWorkItem?
+    @State private var selectionRecenterWorkItem: DispatchWorkItem?
 
     var body: some View {
         GeometryReader { proxy in
@@ -114,6 +118,8 @@ struct AddSearchDetailWaveformTrimView: View {
             stopAutoScrollTimer()
             timelineScrollEndWorkItem?.cancel()
             timelineScrollEndWorkItem = nil
+            selectionRecenterWorkItem?.cancel()
+            selectionRecenterWorkItem = nil
         }
     }
 
@@ -158,7 +164,7 @@ struct AddSearchDetailWaveformTrimView: View {
             RoundedRectangle(cornerRadius: handleCornerRadius)
                 .stroke(AppColors.primary600, lineWidth: selectionBorderLineWidth)
                 .frame(
-                    width: max(endX - startX + handleWidth, handleWidth),
+                    width: max(endX - startX, handleWidth),
                     height: trackHeight - selectionBorderLineWidth
                 )
                 .position(x: (startX + endX) / 2, y: trackHeight / 2)
@@ -177,7 +183,12 @@ struct AddSearchDetailWaveformTrimView: View {
             }
 
             trimHandle(direction: .left)
-                .position(x: startX, y: trackHeight / 2)
+                .scaleEffect(activeHandleDragDirection == .left ? handlePressedScale : 1)
+                .animation(
+                    .spring(response: 0.28, dampingFraction: 0.7),
+                    value: activeHandleDragDirection == .left
+                )
+                .position(x: startX + handleWidth / 2, y: trackHeight / 2)
                 .highPriorityGesture(
                     startHandleDragGesture(
                         contentWidth: contentWidth,
@@ -187,7 +198,12 @@ struct AddSearchDetailWaveformTrimView: View {
                 .zIndex(4)
 
             trimHandle(direction: .right)
-                .position(x: endX, y: trackHeight / 2)
+                .scaleEffect(activeHandleDragDirection == .right ? handlePressedScale : 1)
+                .animation(
+                    .spring(response: 0.28, dampingFraction: 0.7),
+                    value: activeHandleDragDirection == .right
+                )
+                .position(x: endX - handleWidth / 2, y: trackHeight / 2)
                 .highPriorityGesture(
                     endHandleDragGesture(
                         contentWidth: contentWidth,
@@ -251,8 +267,8 @@ struct AddSearchDetailWaveformTrimView: View {
             return nil
         }
 
-        let innerStartX = startX + handleWidth / 2 + playheadWidth / 2
-        let innerEndX = endX - handleWidth / 2 - playheadWidth / 2
+        let innerStartX = startX + handleWidth + playheadWidth / 2
+        let innerEndX = endX - handleWidth - playheadWidth / 2
         guard innerEndX > innerStartX else { return nil }
 
         let clipDuration = max(endSeconds - startSeconds, 0.0001)
@@ -460,21 +476,30 @@ struct AddSearchDetailWaveformTrimView: View {
         guard duration > 0 else { return }
 
         onTrimInteracted()
-        let clipDuration = min(max(currentClipDuration, 1), duration)
-        var newStart = startSeconds + delta
-        var newEnd = newStart + clipDuration
 
-        if newStart < 0 {
-            newStart = 0
-            newEnd = clipDuration
-        }
-        if newEnd > duration {
-            newEnd = duration
-            newStart = max(duration - clipDuration, 0)
+        if currentClipDuration >= maximumClipDuration - 0.001 {
+            let clipDuration = min(max(currentClipDuration, 1), duration)
+            var newStart = startSeconds + delta
+            var newEnd = newStart + clipDuration
+
+            if newStart < 0 {
+                newStart = 0
+                newEnd = clipDuration
+            }
+            if newEnd > duration {
+                newEnd = duration
+                newStart = max(duration - clipDuration, 0)
+            }
+
+            onUpdateRange(newStart, newEnd)
+        } else if delta < 0 {
+            startSeconds += delta
+        } else {
+            endSeconds += delta
         }
 
-        onUpdateRange(newStart, newEnd)
         onInteractionEnded(delta < 0 ? .minusOneSecond : .plusOneSecond)
+        scheduleSelectionRecenter()
     }
 
     private func followScrollButton(direction: HandleDirection) -> some View {
@@ -585,6 +610,8 @@ struct AddSearchDetailWaveformTrimView: View {
                 endActiveHandleDrag()
                 if isTap {
                     onSeekRequested(startSeconds)
+                } else {
+                    scheduleSelectionRecenter()
                 }
             }
     }
@@ -605,6 +632,7 @@ struct AddSearchDetailWaveformTrimView: View {
                 endDragBase = nil
                 onInteractionEnded(.right)
                 endActiveHandleDrag()
+                scheduleSelectionRecenter()
             }
     }
 
@@ -613,8 +641,33 @@ struct AddSearchDetailWaveformTrimView: View {
             activeHandleDragDirection = direction
             activeHandleDragTranslation = 0
             autoScrollAdditionalSeconds = 0
+            selectionRecenterWorkItem?.cancel()
+            selectionRecenterWorkItem = nil
         }
         activeHandleContentWidth = contentWidth
+    }
+
+    private func scheduleSelectionRecenter() {
+        selectionRecenterWorkItem?.cancel()
+        let workItem = DispatchWorkItem {
+            guard activeHandleDragDirection == nil else { return }
+            if let scrollView = timelineScrollView,
+               scrollView.isTracking || scrollView.isDragging || scrollView.isDecelerating {
+                return
+            }
+            scrollTimelineToCenterSelection(animated: true)
+        }
+        selectionRecenterWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + selectionRecenterDelay, execute: workItem)
+    }
+
+    private func scrollTimelineToCenterSelection(animated: Bool) {
+        guard let scrollView = timelineScrollView else { return }
+        let contentWidth = resolvedTimelineContentWidth(for: scrollView)
+        let startX = xPosition(for: startSeconds, contentWidth: contentWidth)
+        let endX = xPosition(for: endSeconds, contentWidth: contentWidth)
+        let offsetX = (startX + endX) / 2 - scrollView.bounds.width / 2
+        setTimelineOffset(offsetX, in: scrollView, animated: animated)
     }
 
     private func endActiveHandleDrag() {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -71,6 +71,7 @@ struct AddSearchDetailWaveformTrimView: View {
     @State private var selectionRecenterWorkItem: DispatchWorkItem?
     @State private var handleLoopWorkItem: DispatchWorkItem?
     @State private var activeLoopDirection: HandleDirection?
+    @State private var leftDragClipDuration: Double?
 
     var body: some View {
         GeometryReader { proxy in
@@ -123,6 +124,7 @@ struct AddSearchDetailWaveformTrimView: View {
                 }
 
                 overviewBar(width: viewportWidth)
+                    .padding(.top, 10)
             }
         }
         .onDisappear {
@@ -393,6 +395,7 @@ struct AddSearchDetailWaveformTrimView: View {
             .foregroundStyle(.white.opacity(0.74))
             .lineLimit(1)
             .minimumScaleFactor(0.7)
+            .contentTransition(.identity)
             .frame(width: handleLabelWidth)
     }
 
@@ -671,6 +674,7 @@ struct AddSearchDetailWaveformTrimView: View {
             .onChanged { value in
                 if startDragBase == nil {
                     startDragBase = startSeconds
+                    leftDragClipDuration = max(endSeconds - startSeconds, 0)
                     onTrimInteracted()
                     scheduleHandleLoopActivation(direction: .left)
                 }
@@ -693,7 +697,9 @@ struct AddSearchDetailWaveformTrimView: View {
                 onInteractionEnded(.left)
                 endActiveHandleDrag()
                 if isTap {
-                    if !didActivateLoop {
+                    if didActivateLoop {
+                        scheduleSelectionRecenter()
+                    } else {
                         onSeekRequested(startSeconds)
                     }
                 } else {
@@ -721,12 +727,13 @@ struct AddSearchDetailWaveformTrimView: View {
                 applyActiveHandleDrag()
             }
             .onEnded { value in
+                let didActivateLoop = activeLoopDirection == .right
                 cancelHandleLoop()
                 onHandleDragMovementChanged(false)
                 endDragBase = nil
                 onInteractionEnded(.right)
                 endActiveHandleDrag()
-                if isBeyondTapThreshold(value.translation) {
+                if isBeyondTapThreshold(value.translation) || didActivateLoop {
                     scheduleSelectionRecenter()
                 }
             }
@@ -747,7 +754,6 @@ struct AddSearchDetailWaveformTrimView: View {
             }
             onHandleLoopActivated(direction == .left ? .left : .right)
             stopAutoScrollTimer()
-            scrollTimelineToCenterSelection(animated: true)
         }
         handleLoopWorkItem = workItem
         DispatchQueue.main.asyncAfter(
@@ -832,6 +838,7 @@ struct AddSearchDetailWaveformTrimView: View {
         activeHandleDragDirection = nil
         activeHandleDragTranslation = 0
         autoScrollAdditionalSeconds = 0
+        leftDragClipDuration = nil
         stopAutoScrollTimer()
         setScrollLock(false)
     }
@@ -845,7 +852,11 @@ struct AddSearchDetailWaveformTrimView: View {
 
         switch direction {
         case .left:
-            startSeconds = (startDragBase ?? startSeconds) + deltaSeconds + autoScrollAdditionalSeconds
+            let clipDuration = leftDragClipDuration ?? currentClipDuration
+            let baseStart = startDragBase ?? startSeconds
+            var newStart = baseStart + deltaSeconds + autoScrollAdditionalSeconds
+            newStart = min(max(newStart, 0), max(duration - clipDuration, 0))
+            onUpdateRange(newStart, newStart + clipDuration)
         case .right:
             endSeconds = (endDragBase ?? endSeconds) + deltaSeconds + autoScrollAdditionalSeconds
         }

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -142,7 +142,13 @@ struct AddSearchDetailWaveformTrimView: View {
         let endX = xPosition(for: endSeconds, contentWidth: contentWidth)
         let selectedWidth = max(endX - startX, 1)
         let trailingWidth = max(contentWidth - endX, 0)
-        let playheadX = playheadXPosition(startX: startX, endX: endX, contentWidth: contentWidth)
+        let loopBandRange = loopBandXRange(startX: startX, endX: endX, contentWidth: contentWidth)
+        let playheadX = playheadXPosition(
+            startX: startX,
+            endX: endX,
+            contentWidth: contentWidth,
+            loopBandRange: loopBandRange
+        )
         let visibleRange = timelineVisibleRange(
             contentWidth: contentWidth,
             fallbackViewportWidth: viewportWidth
@@ -150,12 +156,10 @@ struct AddSearchDetailWaveformTrimView: View {
         let isStartOffscreen = startX < visibleRange.lowerBound - offscreenFollowThreshold
         let isEndOffscreen = endX > visibleRange.upperBound + offscreenFollowThreshold
 
-        let loopBandRange = loopBandXRange(startX: startX, endX: endX, contentWidth: contentWidth)
-
         return ZStack(alignment: .leading) {
             if let loopBandRange {
                 RoundedRectangle(cornerRadius: 5)
-                    .fill(AppColors.primary600.opacity(0.9))
+                    .fill(AppColors.primary600.opacity(0.28))
                     .frame(
                         width: loopBandRange.upperBound - loopBandRange.lowerBound,
                         height: trackHeight - handleVerticalInset * 2
@@ -314,10 +318,26 @@ struct AddSearchDetailWaveformTrimView: View {
     private func playheadXPosition(
         startX: CGFloat,
         endX: CGFloat,
-        contentWidth: CGFloat
+        contentWidth: CGFloat,
+        loopBandRange: ClosedRange<CGFloat>?
     ) -> CGFloat? {
+        guard duration > 0 else { return nil }
+
+        if let loopBandRange, let loopRange = boundaryLoopSecondsRange() {
+            guard
+                playbackSeconds >= loopRange.lowerBound - 0.2,
+                playbackSeconds <= loopRange.upperBound + 0.2
+            else {
+                return nil
+            }
+
+            let loopDuration = max(loopRange.upperBound - loopRange.lowerBound, 0.0001)
+            let ratio = min(max((playbackSeconds - loopRange.lowerBound) / loopDuration, 0), 1)
+            return loopBandRange.lowerBound
+                + CGFloat(ratio) * (loopBandRange.upperBound - loopBandRange.lowerBound)
+        }
+
         guard
-            duration > 0,
             playbackSeconds >= startSeconds - 0.2,
             playbackSeconds <= endSeconds + 0.2
         else {
@@ -331,6 +351,21 @@ struct AddSearchDetailWaveformTrimView: View {
         let clipDuration = max(endSeconds - startSeconds, 0.0001)
         let ratio = min(max((playbackSeconds - startSeconds) / clipDuration, 0), 1)
         return innerStartX + CGFloat(ratio) * (innerEndX - innerStartX)
+    }
+
+    private func boundaryLoopSecondsRange() -> ClosedRange<Double>? {
+        guard let loopDirection = activeLoopDirection else { return nil }
+
+        switch loopDirection {
+        case .left:
+            let upperBound = min(startSeconds + boundaryLoopDuration, endSeconds)
+            guard upperBound > startSeconds else { return nil }
+            return startSeconds...upperBound
+        case .right:
+            let lowerBound = max(endSeconds - boundaryLoopDuration, startSeconds)
+            guard endSeconds > lowerBound else { return nil }
+            return lowerBound...endSeconds
+        }
     }
 
     private func handleTimeLabels(contentWidth: CGFloat) -> some View {
@@ -482,8 +517,15 @@ struct AddSearchDetailWaveformTrimView: View {
             return Color.white.opacity(barOpacity(for: index))
         }
 
-        if let loopBandRange, loopBandRange.contains(centerX) {
-            return Color.black.opacity(0.82)
+        if let loopBandRange {
+            guard loopBandRange.contains(centerX) else {
+                return Color.white.opacity(barOpacity(for: index))
+            }
+
+            if let playheadX, centerX <= playheadX {
+                return AppColors.primary600
+            }
+            return Color.white.opacity(0.95)
         }
 
         if let playheadX, centerX <= playheadX {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -46,7 +46,6 @@ struct AddSearchDetailWaveformTrimView: View {
     private let playheadWidth: CGFloat = 3
     private let handleTapMaxTranslation: CGFloat = 4
     private let selectionBorderLineWidth: CGFloat = 1.5
-    private let maximumClipDuration: Double = 30
     private let handlePressedScale: CGFloat = 1.12
     private let selectionRecenterDelay: TimeInterval = 0.4
     private let handleLoopActivationDelay: TimeInterval = 0.5
@@ -134,7 +133,7 @@ struct AddSearchDetailWaveformTrimView: View {
             selectionRecenterWorkItem = nil
             cancelHandleLoop()
             onHandleDragMovementChanged(false)
-            timelineScrollView?.isScrollEnabled = true
+            setScrollLock(false)
         }
     }
 
@@ -572,34 +571,9 @@ struct AddSearchDetailWaveformTrimView: View {
         guard duration > 0 else { return }
 
         onTrimInteracted()
-
-        if currentClipDuration >= maximumClipDuration - 0.001 {
-            let clipDuration = min(max(currentClipDuration, 1), duration)
-            var newStart = startSeconds + delta
-            var newEnd = newStart + clipDuration
-
-            if newStart < 0 {
-                newStart = 0
-                newEnd = clipDuration
-            }
-            if newEnd > duration {
-                newEnd = duration
-                newStart = max(duration - clipDuration, 0)
-            }
-
-            withAnimation(nudgeAnimation) {
-                onUpdateRange(newStart, newEnd)
-            }
-        } else if delta < 0 {
-            withAnimation(nudgeAnimation) {
-                startSeconds += delta
-            }
-        } else {
-            withAnimation(nudgeAnimation) {
-                endSeconds += delta
-            }
+        withAnimation(nudgeAnimation) {
+            endSeconds += delta
         }
-
         onInteractionEnded(delta < 0 ? .minusOneSecond : .plusOneSecond)
         scheduleSelectionRecenter()
     }
@@ -800,9 +774,31 @@ struct AddSearchDetailWaveformTrimView: View {
             autoScrollAdditionalSeconds = 0
             selectionRecenterWorkItem?.cancel()
             selectionRecenterWorkItem = nil
-            timelineScrollView?.isScrollEnabled = false
+            setScrollLock(true)
         }
         activeHandleContentWidth = contentWidth
+    }
+
+    private func setScrollLock(_ isLocked: Bool) {
+        applyScrollLock(isLocked, to: timelineScrollView)
+        applyScrollLock(isLocked, to: enclosingScrollView(of: timelineScrollView))
+    }
+
+    private func applyScrollLock(_ isLocked: Bool, to scrollView: UIScrollView?) {
+        guard let scrollView else { return }
+        scrollView.isScrollEnabled = !isLocked
+        scrollView.panGestureRecognizer.isEnabled = !isLocked
+    }
+
+    private func enclosingScrollView(of scrollView: UIScrollView?) -> UIScrollView? {
+        var current = scrollView?.superview
+        while let view = current {
+            if let outerScrollView = view as? UIScrollView {
+                return outerScrollView
+            }
+            current = view.superview
+        }
+        return nil
     }
 
     private func scheduleSelectionRecenter() {
@@ -837,7 +833,7 @@ struct AddSearchDetailWaveformTrimView: View {
         activeHandleDragTranslation = 0
         autoScrollAdditionalSeconds = 0
         stopAutoScrollTimer()
-        timelineScrollView?.isScrollEnabled = true
+        setScrollLock(false)
     }
 
     private func applyActiveHandleDrag() {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/AddSearchDetailWaveformTrimView.swift
@@ -134,6 +134,7 @@ struct AddSearchDetailWaveformTrimView: View {
             selectionRecenterWorkItem = nil
             cancelHandleLoop()
             onHandleDragMovementChanged(false)
+            timelineScrollView?.isScrollEnabled = true
         }
     }
 
@@ -699,6 +700,7 @@ struct AddSearchDetailWaveformTrimView: View {
                     onTrimInteracted()
                     scheduleHandleLoopActivation(direction: .left)
                 }
+                guard activeLoopDirection == nil else { return }
                 activateDrag(direction: .left, contentWidth: contentWidth)
                 activeHandleDragTranslation = value.translation.width
                 if isBeyondTapThreshold(value.translation) {
@@ -734,6 +736,7 @@ struct AddSearchDetailWaveformTrimView: View {
                     onTrimInteracted()
                     scheduleHandleLoopActivation(direction: .right)
                 }
+                guard activeLoopDirection == nil else { return }
                 activateDrag(direction: .right, contentWidth: contentWidth)
                 activeHandleDragTranslation = value.translation.width
                 if isBeyondTapThreshold(value.translation) {
@@ -770,7 +773,6 @@ struct AddSearchDetailWaveformTrimView: View {
             }
             onHandleLoopActivated(direction == .left ? .left : .right)
             stopAutoScrollTimer()
-            timelineScrollView?.isScrollEnabled = false
             scrollTimelineToCenterSelection(animated: true)
         }
         handleLoopWorkItem = workItem
@@ -787,7 +789,6 @@ struct AddSearchDetailWaveformTrimView: View {
             withAnimation(.easeInOut(duration: 0.2)) {
                 activeLoopDirection = nil
             }
-            timelineScrollView?.isScrollEnabled = true
             onHandleLoopDeactivated()
         }
     }
@@ -799,6 +800,7 @@ struct AddSearchDetailWaveformTrimView: View {
             autoScrollAdditionalSeconds = 0
             selectionRecenterWorkItem?.cancel()
             selectionRecenterWorkItem = nil
+            timelineScrollView?.isScrollEnabled = false
         }
         activeHandleContentWidth = contentWidth
     }
@@ -835,6 +837,7 @@ struct AddSearchDetailWaveformTrimView: View {
         activeHandleDragTranslation = 0
         autoScrollAdditionalSeconds = 0
         stopAutoScrollTimer()
+        timelineScrollView?.isScrollEnabled = true
     }
 
     private func applyActiveHandleDrag() {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
@@ -82,6 +82,8 @@ struct YoutubePlayerView: UIViewRepresentable {
     let endSeconds: Double
     let isPlaying: Bool
     let playbackFocusToken: Int
+    let seekSeconds: Double?
+    let seekToken: Int
     let shouldLoopPlayback: Bool
     let allowsMutedAutoplayFallback: Bool
     let respectsUserInteraction: Bool
@@ -96,6 +98,8 @@ struct YoutubePlayerView: UIViewRepresentable {
         endSeconds: Double,
         isPlaying: Bool = true,
         playbackFocusToken: Int = 0,
+        seekSeconds: Double? = nil,
+        seekToken: Int = 0,
         shouldLoopPlayback: Bool = true,
         allowsMutedAutoplayFallback: Bool = true,
         respectsUserInteraction: Bool = true,
@@ -109,6 +113,8 @@ struct YoutubePlayerView: UIViewRepresentable {
         self.endSeconds = endSeconds
         self.isPlaying = isPlaying
         self.playbackFocusToken = playbackFocusToken
+        self.seekSeconds = seekSeconds
+        self.seekToken = seekToken
         self.shouldLoopPlayback = shouldLoopPlayback
         self.allowsMutedAutoplayFallback = allowsMutedAutoplayFallback
         self.respectsUserInteraction = respectsUserInteraction
@@ -175,6 +181,7 @@ struct YoutubePlayerView: UIViewRepresentable {
             context.coordinator.lastSyncedRespectsUserInteraction = respectsUserInteraction
             context.coordinator.lastSyncedShowsMutedFallbackControl = showsMutedFallbackControl
             context.coordinator.lastSyncedPlaybackFocusToken = playbackFocusToken
+            context.coordinator.lastSyncedSeekToken = seekToken
             context.coordinator.hasDispatchedEnded = false
             webView.loadHTMLString(
                 makePlayerHTML(
@@ -192,6 +199,21 @@ struct YoutubePlayerView: UIViewRepresentable {
                 baseURL: appRefererURL
             )
             return
+        }
+
+        if context.coordinator.lastSyncedSeekToken != seekToken {
+            context.coordinator.lastSyncedSeekToken = seekToken
+            if let seekSeconds {
+                context.coordinator.hasDispatchedEnded = false
+                webView.evaluateJavaScript(
+                    """
+                    if (window.kpSeekTo) {
+                        window.kpSeekTo(\(jsNumber(seekSeconds)), true);
+                    }
+                    """,
+                    completionHandler: nil
+                )
+            }
         }
 
         let isSameStart = isApproximatelyEqual(
@@ -312,6 +334,7 @@ struct YoutubePlayerView: UIViewRepresentable {
         var lastSyncedRespectsUserInteraction: Bool?
         var lastSyncedShowsMutedFallbackControl: Bool?
         var lastSyncedPlaybackFocusToken: Int?
+        var lastSyncedSeekToken: Int?
         var redirectURL: URL?
         var openExternalURL: ((URL) -> Void)?
         var onPlaybackEnded: (() -> Void)?
@@ -927,6 +950,27 @@ struct YoutubePlayerView: UIViewRepresentable {
                         window.kpPlayer.playVideo();
                     }
                 }
+
+                window.kpSeekTo = function(seconds, shouldPlay) {
+                    if (!window.kpPlayerReady || !window.kpPlayer) {
+                        return;
+                    }
+
+                    var target = Number(seconds);
+                    if (isNaN(target) || target < 0) {
+                        return;
+                    }
+
+                    window.kpHasDispatchedEnded = false;
+                    window.kpStallStartedAt = 0;
+                    if (window.kpPlayer.seekTo) {
+                        window.kpPlayer.seekTo(target, true);
+                    }
+                    if (shouldPlay && window.kpPlayer.playVideo) {
+                        window.kpPlayer.playVideo();
+                    }
+                    kpPostProgress();
+                };
 
                 function kpPostProgress() {
                     if (!window.kpPlayerReady || !window.kpPlayer) {

--- a/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
+++ b/KillingPart/Views/Screens/Main/Add/AddSearchDetail/components/YoutubePlayerView.swift
@@ -290,7 +290,7 @@ struct YoutubePlayerView: UIViewRepresentable {
         let respectsUserInteractionJS = respectsUserInteraction ? "true" : "false"
         let showsMutedFallbackControlJS = showsMutedFallbackControl ? "true" : "false"
         let isLowPowerModeEnabledJS = isLowPowerModeEnabled ? "true" : "false"
-        let shouldResetControlModeJS = (isRangeChanged || (isPlayStateChanged && isPlaying)) ? "true" : "false"
+        let shouldResetControlModeJS = (isPlayStateChanged && isPlaying) ? "true" : "false"
 
         webView.evaluateJavaScript(
             """


### PR DESCRIPTION
## 작업 내용

- [x] 재생방법 업데이트
    -  현재 재생위치표시 인디게이터 추가
    - 기준색상으로 구간 색상 채우기
    - 스펙트럼 중간을 터치하여 해당 부분부터 재생
    - 좌측 핸들 이벤트 시 처음부터 다시재생
- [x] 구간 조절 방법 업데이트
    - 핸들 이벤트 시 확대 애니메이션 추가
    - 핸들 드래그앤 드롭 시 중앙 정렬(0.3~0.5초 딜레이)
    - 좌측 핸들은 전체 스팩트럼 움직이기
- [x] +/- 1s 버튼 추가
    - +/- 1s 우측 핸들만 적용
    - 재생 유지
- [x] 앞뒤 2초 루프
    - 0.5초 이벤트 시 루프 2초 재생(누르고 있는 동안 반복)
- [x] 힌트 메시지 추가(최초 1회만 발생)
